### PR TITLE
Change token name and symbol for Mark

### DIFF
--- a/src/tokens/mainnet-beta.json
+++ b/src/tokens/mainnet-beta.json
@@ -205,7 +205,7 @@
     "website": "https://tether.to"
   },
   {
-    "tokenSymbol": "MARK",
+    "tokenSymbol": "xMARK",
     "mintAddress": "2oDxYGgTBmST4rc3yn1YtcSEck7ReDZ8wHWLqZAuNWXH",
     "tokenName": "Benchmark",
     "icon": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/2oDxYGgTBmST4rc3yn1YtcSEck7ReDZ8wHWLqZAuNWXH/logo.png",

--- a/src/tokens/mainnet-beta.json
+++ b/src/tokens/mainnet-beta.json
@@ -207,7 +207,7 @@
   {
     "tokenSymbol": "xMARK",
     "mintAddress": "2oDxYGgTBmST4rc3yn1YtcSEck7ReDZ8wHWLqZAuNWXH",
-    "tokenName": "Benchmark",
+    "tokenName": "Standard",
     "icon": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/2oDxYGgTBmST4rc3yn1YtcSEck7ReDZ8wHWLqZAuNWXH/logo.png",
     "website": "https://benchmarkprotocol.finance/"
   },


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Updating token symbol and name

- **What is the current behavior?** (You can also link to an open issue here)

display token name as Benchmark and symbol as Mark

- **What is the new behavior (if this is a feature change)?**

Display token name as Standard and symbol as xMark

- **Other information**:

None
