### PR TITLE
Throw when slug does not exist

### DIFF
--- a/src/lib/tokenlist.spec.ts
+++ b/src/lib/tokenlist.spec.ts
@@ -1,6 +1,6 @@
 import test from 'ava';
 
-import { ENV, Strategy, TokenListProvider } from './tokenlist';
+import { CLUSTER_SLUGS, ENV, Strategy, TokenListProvider } from './tokenlist';
 
 test('Token list is filterable by a tag', async (t) => {
   const list = (await new TokenListProvider().resolve(Strategy.Static))
@@ -33,4 +33,10 @@ test('Token list returns new object upon filter', async (t) => {
   const filtered = list.filterByChainId(ENV.MainnetBeta);
   t.true(list !== filtered);
   t.true(list.getList().length !== filtered.getList().length);
+});
+
+test('Token list throws error when calling filgerByClusterSlug with slug that does not exist', async (t) => {
+  const list = await new TokenListProvider().resolve(Strategy.Static);
+  const error = await t.throwsAsync(async () => list.filterByClusterSlug('whoop'), { instanceOf: Error });
+  t.is(error.message, `Unknown slug: whoop, please use one of ${Object.keys(CLUSTER_SLUGS)}`);
 });

--- a/src/lib/tokenlist.ts
+++ b/src/lib/tokenlist.ts
@@ -124,7 +124,7 @@ export class TokenListProvider {
 }
 
 export class TokenListContainer {
-  constructor(private tokenList: TokenInfo[]) {}
+  constructor(private tokenList: TokenInfo[]) { }
 
   filterByTag = (tag: string) => {
     return new TokenListContainer(
@@ -154,7 +154,7 @@ export class TokenListContainer {
     if (slug in CLUSTER_SLUGS) {
       return this.filterByChainId(CLUSTER_SLUGS[slug]);
     }
-    return this;
+    throw new Error(`Unknown slug: ${slug}, please use one of ${Object.keys(CLUSTER_SLUGS)}`);
   };
 
   getList = () => {


### PR DESCRIPTION
I was writing some code integrating with `TokenListProvider`, to my surprise it returns the entire original `TokenListContainer` when the slug does not exist. That's not great, I propose to raise instead. However, I am not sure what type of Error it should be...

Or maybe return an empty array, that would make it similar to a regular `.filter`