### PR TITLE
Added oDop to tokenlist

### DIFF
--- a/src/tokens/solana.tokenlist.json
+++ b/src/tokens/solana.tokenlist.json
@@ -4925,6 +4925,18 @@
          }
       },
     {
+       "chainId":101,
+       "address":"4pk3pf9nJDN1im1kNwWJN1ThjE8pCYCTexXYGyFjqKVf",
+       "symbol":"oDOP",
+       "name":"Dominican Pesos",
+       "decimals":9,
+       "logoURI":"https://user-images.githubusercontent.com/9972260/111077928-73bd2280-84c9-11eb-84d4-4032478e3861.png",
+       "tags": ["stablecoin"],
+       "extensions": {
+        "website": "https://Odop.io/"
+      }
+    },
+    {
       "chainId": 102,
       "address": "So11111111111111111111111111111111111111112",
       "symbol": "SOL",


### PR DESCRIPTION
- [X] I will not ping the Discord about this pull request.

* Token Address:  4pk3pf9nJDN1im1kNwWJN1ThjE8pCYCTexXYGyFjqKVf
* Token Name: Dominican Pesos
* Token Symbol: oDOP
* Logo
* Link to the official homepage of token: https://Odop.io/

oDOP is a stable coin based on Dominican Peso, the official currency of Dominican Republic.

The oDOP cryptocurrency works with a single entity OuroSRL which is the sole minter of the oDOP token. Traders that mint/redeem oDOP are subject to KYC/AML checks and only after having passing those then they can purchase or redeem the oDOP token. Sales of oDOP for fiat currencies only occur in the Dominican Republic.