### PR TITLE
Wrapped sol for devnet too

### DIFF
--- a/src/tokens/solana.tokenlist.json
+++ b/src/tokens/solana.tokenlist.json
@@ -5205,7 +5205,7 @@
       "chainId": 103,
       "address": "So11111111111111111111111111111111111111112",
       "symbol": "SOL",
-      "name": "Solana",
+      "name": "Wrapped SOL",
       "decimals": 9,
       "logoURI": "https://cdn.jsdelivr.net/gh/trustwallet/assets/blockchains/solana/info/logo.png",
       "tags": []


### PR DESCRIPTION
Working on sollet.io usage of token-list i noticed that Wrapped SOL shows as Solana. This is so it shows the same as mainnet-beta or testnet.