### PR TITLE
fix: change step token to png

### DIFF
--- a/src/tokens/solana.tokenlist.json
+++ b/src/tokens/solana.tokenlist.json
@@ -6023,7 +6023,7 @@
       "symbol": "STEP",
       "name": "Step",
       "decimals": 9,
-      "logoURI": "https://cdn.jsdelivr.net/gh/solana-labs/token-list/assets/mainnet/StepAscQoEioFxxWGnh2sLBDFp9d8rvKz2Yp39iDpyT/logo.jpg",
+      "logoURI": "https://cdn.jsdelivr.net/gh/solana-labs/token-list/assets/mainnet/StepAscQoEioFxxWGnh2sLBDFp9d8rvKz2Yp39iDpyT/logo.png",
       "tags": [],
       "extensions": {
         "website": "https://step.finance/"


### PR DESCRIPTION
- [x] I will not ping the Discord about this pull request.

The STEP Logo is listed incorrectly as a `.jpg` and should be a `.png`.