### PR TITLE
Add SBFC Token

### DIFF
--- a/src/tokens/solana.tokenlist.json
+++ b/src/tokens/solana.tokenlist.json
@@ -7259,6 +7259,24 @@
         "website": "https://muskimum.win/",
         "twitter": "https://twitter.com/muskimum"
       }
+    },
+    {
+      "chainId": 101,
+      "address": "AWW5UQfMBnPsTaaxCK7cSEmkj1kbX2zUrqvgKXStjBKx",
+      "symbol": "SBFC",
+      "name": "SBF Coin",
+      "decimals": 6,
+      "logoURI": "https://www.sbfcoin.com/images/sbfcoin.png",
+      "tags": [
+        "utility-token",
+        "SBF",
+        "sbfcoin",
+        "SBFC"
+      ],
+      "extensions": {
+        "website": "https://www.sbfcoin.com/",
+        "twitter": "https://twitter.com/sbfcoin"
+      }
     }
   ],
   "version": {


### PR DESCRIPTION
- [ ] I will not ping the Discord about this pull request.

SBFC is meme coin for SBF and his fans, built on Solana. The mission of SBFC is to incentivize community of SBF's fans to promote FTX and Solana ecosystem, help Dapps on Solana to scale and improve ease of use.

* Token Address: AWW5UQfMBnPsTaaxCK7cSEmkj1kbX2zUrqvgKXStjBKx
* Token Name: SBF Coin
* Token Symbol: SBFC
* Logo: https://sbfcoin.org/images/sbfcoin.png
* Link to the official homepage of token: https://sbfcoin.org
