### PR TITLE
Fix new cope decimals

### DIFF
--- a/src/tokens/solana.tokenlist.json
+++ b/src/tokens/solana.tokenlist.json
@@ -6380,7 +6380,7 @@
       "address": "8HGyAAB1yoM1ttS7pXjHMa3dukTFGQggnFFH3hJZgzQh",
       "symbol": "COPE",
       "name": "COPE",
-      "decimals": 0,
+      "decimals": 6,
       "logoURI": "https://cdn.jsdelivr.net/gh/solana-labs/token-list@main/assets/mainnet/3K6rftdAaQYMPunrtNRHgnK2UAtjm2JwyT2oCiTDouYE/logo.jpg",
       "tags": [
         "trading",


### PR DESCRIPTION
The new COPE has 6 decimals (not 0)