### PR TITLE
Fix mango market caps decimals in tokenlist.json

### DIFF
--- a/src/tokens/solana.tokenlist.json
+++ b/src/tokens/solana.tokenlist.json
@@ -6398,7 +6398,7 @@
       "address": "2prC8tcVsXwVJAinhxd2zeMeWMWaVyzPoQeLKyDZRFKd",
       "symbol": "MCAPS",
       "name": "Mango Market Caps",
-      "decimals": 6,
+      "decimals": 0,
       "logoURI": "https://cdn.jsdelivr.net/gh/solana-labs/token-list@main/assets/mainnet/2prC8tcVsXwVJAinhxd2zeMeWMWaVyzPoQeLKyDZRFKd/logo.png",
       "tags": [
         "mango"


### PR DESCRIPTION
Decimals should be 0

https://explorer.solana.com/address/2prC8tcVsXwVJAinhxd2zeMeWMWaVyzPoQeLKyDZRFKd

- [x] I will not ping the Discord about this pull request.

**Please provide the following information for your token.**

Please include change to the src/lib/<env>.json and in the PR

At minimum each entry should have
* Token Address: 
* Token Name: 
* Token Symbol: 
* Logo
* Link to the official homepage of token:
* Coingecko ID if available (https://www.coingecko.com/api/documentations/v3#/coins/get_coins__id_):
