### PR TITLE
Change ECOP Token Account

### DIFF
--- a/src/tokens/solana.tokenlist.json
+++ b/src/tokens/solana.tokenlist.json
@@ -7607,7 +7607,7 @@
     },
     {
       "chainId": 101,
-      "address": "G1NtMGrXmW92ar4wMv4WnQof9V5M3FsRFJT6E5rD96d5",
+      "address": "FRbqQnbuLoMbUG4gtQMeULgCDHyY6YWF9NRUuLa98qmq",
       "symbol": "ECOP",
       "name": "EcoPoo",
       "decimals": 0,


### PR DESCRIPTION
The reason for the change is we've failed to deliver the airdrop properly using the old one.

- [x] I will not ping the Discord about this pull request.