### PR TITLE
update waterfallbot url for SPL tokens

### DIFF
--- a/src/tokens/solana.tokenlist.json
+++ b/src/tokens/solana.tokenlist.json
@@ -65,7 +65,8 @@
         "website": "https://solana.com/",
         "serumV3Usdc": "9wFFyRfZBsuAha4YcuxcXLKwMxJR43S7fPfQLusDBzvT",
         "serumV3Usdt": "HWHvQhFmJB3NUcu1aihKmrKegfVxBEHzwVX6yZCKEsi1",
-        "coingeckoId": "solana"
+        "coingeckoId": "solana",
+				"waterfallbot": "https://t.me/SOLwaterfall"
       }
     },
     {
@@ -205,7 +206,8 @@
         "bridgeContract": "https://etherscan.io/address/0xeae57ce9cc1984f202e15e038b964bb8bdf7229a",
         "serumV3Usdc": "A1Q9iJDVVS8Wsswr9ajeZugmj64bQVCYLZQLra2TMBMo",
         "serumV3Usdt": "6DgQRTpJTnAYBSShngAVZZDq7j9ogRN1GfSQ3cq9tubW",
-        "coingeckoId": "sushi"
+        "coingeckoId": "sushi",
+				"waterfallbot": "https://bit.ly/SUSHIwaterfall"
       }
     },
     {
@@ -402,7 +404,8 @@
         "website": "https://projectserum.com/",
         "serumV3Usdc": "ByRys5tuUWDgL73G8JBAEfkdFf8JWBzPBDHsBVQ5vbQA",
         "serumV3Usdt": "AtNnsY1AyRERWJ8xCskfz38YdvruWVJQUVXgScC1iPb",
-        "coingeckoId": "serum"
+        "coingeckoId": "serum",
+				"waterfallbot": "https://bit.ly/SRMwaterfall"
       }
     },
     {
@@ -421,7 +424,8 @@
         "assetContract": "https://etherscan.io/address/0x50d1c9771902476076ecfc8b2a83ad6b9355a4c9",
         "serumV3Usdc": "2Pbh1CvRVku1TgewMfycemghf6sU9EyuFDcNXqvRmSxc",
         "serumV3Usdt": "Hr3wzG8mZXNHV7TuL6YqtgfVUesCqMxGYCEyP3otywZE",
-        "coingeckoId": "ftx-token"
+        "coingeckoId": "ftx-token",
+				"waterfallbot": "https://bit.ly/FTTwaterfall"
       }
     },
     {
@@ -470,7 +474,8 @@
         "bridgeContract": "https://etherscan.io/address/0xeae57ce9cc1984f202e15e038b964bb8bdf7229a",
         "serumV3Usdc": "8BdpjpSD5n3nk8DQLqPUyTZvVqFu6kcff5bzUX5dqDpy",
         "serumV3Usdt": "GnKPri4thaGipzTbp8hhSGSrHgG4F8MFiZVrbRn16iG2",
-        "coingeckoId": "tomochain"
+        "coingeckoId": "tomochain",
+        "waterfallbot": "https://t.me/TOMOwaterfall"
       }
     },
     {
@@ -504,7 +509,8 @@
         "bridgeContract": "https://etherscan.io/address/0xeae57ce9cc1984f202e15e038b964bb8bdf7229a",
         "serumV3Usdc": "4xyWjQ74Eifq17vbue5Ut9xfFNfuVB116tZLEpiZuAn8",
         "serumV3Usdt": "35tV8UsHH8FnSAi3YFRrgCu4K9tb883wKnAXpnihot5r",
-        "coingeckoId": "lua-token"
+        "coingeckoId": "lua-token",
+        "waterfallbot": "https://t.me/LUAwaterfall"
       }
     },
     {
@@ -685,7 +691,8 @@
         "website": "https://bonfida.com/",
         "serumV3Usdc": "E14BKBhDWD4EuTkWj1ooZezesGxMW8LPCps4W5PuzZJo",
         "serumV3Usdt": "EbV7pPpEvheLizuYX3gUCvWM8iySbSRAhu2mQ5Vz2Mxf",
-        "coingeckoId": "bonfida"
+        "coingeckoId": "bonfida",
+				"waterfallbot": "https://bit.ly/FIDAwaterfall"
       }
     },
     {
@@ -699,7 +706,8 @@
       "extensions": {
         "serumV3Usdc": "Bn6NPyr6UzrFAwC4WmvPvDr2Vm8XSUnFykM2aQroedgn",
         "serumV3Usdt": "4nCFQr8sahhhL4XJ7kngGFBmpkmyf3xLzemuMhn6mWTm",
-        "coingeckoId": "kin"
+        "coingeckoId": "kin",
+        "waterfallbot": "https://bit.ly/KINwaterfall"
       }
     },
     {
@@ -729,7 +737,8 @@
         "website": "https://www.oxygen.org/",
         "serumV3Usdt": "GKLev6UHeX1KSDCyo2bzyG6wqhByEzDBkmYTxEdmYJgB",
         "serumV3Usdc": "GZ3WBFsqntmERPwumFEYgrX2B7J7G11MzNZAy7Hje27X",
-        "coingeckoId": "oxygen"
+        "coingeckoId": "oxygen",
+        "waterfallbot": "https://bit.ly/OXYwaterfall"
       }
     },
     {
@@ -792,7 +801,8 @@
         "website": "https://raydium.io/",
         "serumV3Usdt": "teE55QrL4a4QSfydR9dnHF97jgCfptpuigbb53Lo95g",
         "serumV3Usdc": "2xiv8A5xrJ7RnGdxXB42uFEkYHJjszEhaJyKKt4WaLep",
-        "coingeckoId": "raydium"
+        "coingeckoId": "raydium",
+				"waterfallbot": "https://bit.ly/RAYwaterfall"
       }
     },
     {
@@ -6486,7 +6496,8 @@
       "extensions": {
         "website": "https://ropesolana.com/",
         "coingeckoId": "rope-token",
-        "serumV3Usdc": "4Sg1g8U2ZuGnGYxAhc6MmX9MX7yZbrrraPkCQ9MdCPtF"
+        "serumV3Usdc": "4Sg1g8U2ZuGnGYxAhc6MmX9MX7yZbrrraPkCQ9MdCPtF",
+        "waterfallbot": "https://bit.ly/ROPEwaterfall"
       }
     },
     {
@@ -6520,7 +6531,8 @@
       "extensions": {
         "website": "https://media.network/",
         "coingeckoId": "media-network",
-        "serumV3Usdc": "FfiqqvJcVL7oCCu8WQUMHLUC2dnHQPAPjTdSzsERFWjb"
+        "serumV3Usdc": "FfiqqvJcVL7oCCu8WQUMHLUC2dnHQPAPjTdSzsERFWjb",
+        "waterfallbot": "https://bit.ly/MEDIAwaterfall"
       }
     },
     {
@@ -6537,7 +6549,8 @@
         "website": "https://step.finance/",
         "twitter": "https://twitter.com/StepFinance_",
         "coingeckoId": "step-finance",
-        "serumV3Usdc": "97qCB4cAVSTthvJu3eNoEx6AY6DLuRDtCoPm5Tdyg77S"
+        "serumV3Usdc": "97qCB4cAVSTthvJu3eNoEx6AY6DLuRDtCoPm5Tdyg77S",
+        "waterfallbot": "https://bit.ly/STEPwaterfall"
       }
     },
     {
@@ -6775,7 +6788,8 @@
       "logoURI": "https://cdn.jsdelivr.net/gh/solana-labs/token-list@main/assets/mainnet/xxxxa1sKNGwFtw2kFn8XauW9xq8hBZ5kVtcSesTT9fW/logo.png",
       "tags": [],
       "extensions": {
-        "website": "https://solanium.io/"
+        "website": "https://solanium.io/",
+        "waterfallbot": "https://bit.ly/SLIMwaterfall"
       }
     },
     {
@@ -7274,7 +7288,8 @@
       "extensions": {
         "coingeckoId": "mercurial",
         "website": "https://www.mercurial.finance/",
-        "serumV3Usdc": "G4LcexdCzzJUKZfqyVDQFzpkjhB1JoCNL8Kooxi9nJz5"
+        "serumV3Usdc": "G4LcexdCzzJUKZfqyVDQFzpkjhB1JoCNL8Kooxi9nJz5",
+        "waterfallbot": "https://bit.ly/MERwaterfall"
       }
     },
     {
@@ -7507,7 +7522,8 @@
         "website": "https://solfarm.io",
         "twitter": "https://twitter.com/Solfarmio",
         "coingeckoId": "solfarm",
-        "serumV3Usdc": "8GufnKq7YnXKhnB3WNhgy5PzU9uvHbaaRrZWQK6ixPxW"
+        "serumV3Usdc": "8GufnKq7YnXKhnB3WNhgy5PzU9uvHbaaRrZWQK6ixPxW",
+        "waterfallbot": "https://bit.ly/TULIPwaterfall"
       }
     },
     {


### PR DESCRIPTION
- [x] I will not ping the Discord about this pull request.

[waterfallbot](https://t.me/CENTRALwaterfall) now support realtime tracking trades of SPL tokens on SerumV3
We include waterfallbot url of tokens as an extension so other parties like solanabeach, solscan ... can display it in token page

Supported tokens:
- [x] Solana - SOL
- [x] Serum - SRM 
- [x] Wrapped FTX token - FTT 
- [x] Wrapped Sushi - SUSHI
- [x] Wrapped Lua Token - LUA
- [x] Wrapped Tomo - TOMO
- [x] Mercurial - MER
- [x] Oxygen - OXY
- [x] Solfarm Token - TULIP
- [x] Bonfida Token - FIDA
- [x] Rope Token - ROPE
- [x] Media Network - MEDIA
- [x] Step Finance Token - STEP
- [x] Solanium - SLIM
 

Thank you