### PR TITLE
fix: resolve to not be async when it is not needed

### DIFF
--- a/src/lib/tokenlist.ts
+++ b/src/lib/tokenlist.ts
@@ -64,7 +64,7 @@ export class GitHubTokenListResolutionStrategy {
     'https://raw.githubusercontent.com/solana-labs/token-list/main/src/tokens/solana.tokenlist.json',
   ];
 
-  resolve = async () => {
+  resolve = () => {
     return queryJsonFiles(this.repositories);
   };
 }
@@ -74,7 +74,7 @@ export class CDNTokenListResolutionStrategy {
     'https://cdn.jsdelivr.net/gh/solana-labs/token-list@main/src/tokens/solana.tokenlist.json',
   ];
 
-  resolve = async () => {
+  resolve = () => {
     return queryJsonFiles(this.repositories);
   };
 }
@@ -108,13 +108,13 @@ export enum Strategy {
 }
 
 export class SolanaTokenListResolutionStrategy {
-  resolve = async () => {
+  resolve = () => {
     throw new Error(`Not Implemented Yet.`);
   };
 }
 
 export class StaticTokenListResolutionStrategy {
-  resolve = async () => {
+  resolve = () => {
     return tokenlist.tokens;
   };
 }


### PR DESCRIPTION
- [X] I will not ping the Discord about this pull request.

This would allow static strategy `.resolve` to be used synchronously.