### PR TITLE
Replace incorrect SRM market address with correct mint address

### DIFF
--- a/src/tokens/solana.tokenlist.json
+++ b/src/tokens/solana.tokenlist.json
@@ -9010,7 +9010,7 @@
     },
     {
       "chainId": 101,
-      "address": "7MtgLYSEgsq626pvcEAwaDqs2KiZsaJUX2qGpRZbcDWY",
+      "address": "FmJ1fo7wK5FF6rDvQxow5Gj7A2ctLmR5orCKLZ45Q3Cq",
       "symbol": "DGEN",
       "name": "Degen Banana",
       "decimals": 6,


### PR DESCRIPTION
Accidentally submitted wrong address for the $DGEN token