### PR TITLE
Add PAI (Parrot Stablecoin)

### DIFF
--- a/src/tokens/solana.tokenlist.json
+++ b/src/tokens/solana.tokenlist.json
@@ -9503,6 +9503,20 @@
     },
     {
       "chainId": 101,
+      "address": "Ea5SjE2Y6yvCeW5dYTn7PYMuW5ikXkvbGdcmSnXeaLjS",
+      "symbol": "PAI",
+      "name": "PAI (Parrot)",
+      "decimals": 6,
+      "logoURI": "https://partyparrot.finance/images/tokens/pai.svg",
+      "tags": ["stablecoin"],
+      "extensions": {
+        "website": "https://partyparrot.finance",
+        "twitter": "https://twitter.com/gopartyparrot",
+        "telegram": "https://t.me/gopartyparrot"
+      }
+    },
+    {
+      "chainId": 101,
       "address": "Fx14roJm9m27zngJQwmt81npHvPc5pmF772nxDhNnsh5",
       "symbol": "LIQ-USDC",
       "name": "Raydium LP Token (LIQ-USDC)",


### PR DESCRIPTION
The PAI mint address `Ea5SjE2Y6yvCeW5dYTn7PYMuW5ikXkvbGdcmSnXeaLjS` can be seen in our official security documentation:

https://doc.partyparrot.finance/security/mainnet.html#debttype

- [x ] I will not ping the Discord about this pull request.

