### PR TITLE
fix: add missing "tags" field to renBTC

### DIFF
--- a/src/tokens/solana.tokenlist.json
+++ b/src/tokens/solana.tokenlist.json
@@ -10415,6 +10415,7 @@
       "name": "Ren Bitcoin",
       "decimals": 8,
       "logoURI": "https://cdn.jsdelivr.net/gh/trustwallet/assets@master/blockchains/ethereum/assets/0xEB4C2781e4ebA804CE9a9803C67d0893436bB27D/logo.png",
+      "tags": [],
       "extensions": {
         "website": "https://renproject.io/",
         "coingeckoId": "renbtc"


### PR DESCRIPTION
- I will not ping the Discord about this pull request.

FIX: "tags" field is missing on renBTC (CDJWUqTcYTVAKXAVXoQZFes5JUFc7owSeq7eMQcDSbo5)
