### PR TITLE
Add coingeckoId extension for Sunny Aggregator

### DIFF
--- a/src/tokens/solana.tokenlist.json
+++ b/src/tokens/solana.tokenlist.json
@@ -11858,7 +11858,8 @@
         "github": "https://github.com/SunnyAggregator",
         "medium": "https://medium.com/sunny-aggregator",
         "discord": "https://chat.sunny.ag",
-        "serumV3Usdc": "Aubv1QBFh4bwB2wbP1DaPW21YyQBLfgjg8L4PHTaPzRc"
+        "serumV3Usdc": "Aubv1QBFh4bwB2wbP1DaPW21YyQBLfgjg8L4PHTaPzRc",
+        "coingeckoId": "sunny-aggregator"
       }
     },
     {


### PR DESCRIPTION
This PR adds the `coingeckoId` extension for Sunny Aggregator.

This data was not available when #811 was merged, and this PR avoids the merge conflict and duplicate icon that's blocking #850.