### PR TITLE
Correct Coingeckoid for OXS solana bull Token

### DIFF
--- a/src/tokens/solana.tokenlist.json
+++ b/src/tokens/solana.tokenlist.json
@@ -10843,7 +10843,7 @@
         "twitter": "https://twitter.com/OxBull5",
         "medium": "https://medium.com/@oxbull",
         "tgann": "https://t.me/Oxbull_tech",
-        "coingeckoId": "oxbull-tech",
+        "coingeckoId": "oxbull-solana",
         "github": "https://github.com/OxBull"
       }
     },


### PR DESCRIPTION
### Summary

The OXS bull token was using the incorrect coingeckoId which was causing price issues for many services: 
https://explorer.solana.com/address/4TGxgCSJQx2GQk9oHZ8dC5m3JNXTYZHjXumKAW3vLnNx/largest

Here is the correct coingecko price:
https://www.coingecko.com/en/coins/oxbull-solana

`oxbull-tech` is the bsc token coingecko id
`oxbull-solana` is the new OXS solana token coingecko id