### PR TITLE
Add KUGLE BOX utility token

### DIFF
--- a/src/tokens/solana.tokenlist.json
+++ b/src/tokens/solana.tokenlist.json
@@ -15802,6 +15802,21 @@
         "twitter": "https://twitter.com/SalvadorUsd",
          "Telegram": "https://t.me/salvadousd"
       }
+    },
+    {
+      "chainId": 101,
+      "address": "2pMNgs7Arn1oQBNSb65Aj55rY2zpWHV9JkuqK6ZoetCj",
+      "symbol": "KBX",
+      "name": "KUGLE-BOX",
+      "decimals": 0,
+      "logoURI": "https://cdn.jsdelivr.net/gh/Seigneur-Machiavel/kugle.github.io/Tokens/KBX_200.png",
+      "tags": [
+        "utility-token"
+      ],
+      "extensions": {
+        "website": "https://kugle.org",
+        "twitter": "https://twitter.com/Kugle_"
+      }
     }
   ],
   "version": {


### PR DESCRIPTION
A simple token with 0 Decimal used in the MINT process of Kugle Eggs NFT (like Raydium Dropzone DropBox token)

## I agree to not ping _anybody_ on Discord/Twitter/email about this pull request. Instead I will inquire by posting a new comment in the pull request if needed.

---

PRs are reviewed in bulk and and can take up to **two weeks** to be merged.

_This repository is managed using an auto merge action. Please ensure your PR has no deleted lines, and it will be merged._

## **Please provide the following information for your token.**

Please include change to the `src/tokens/solana.tokenlist.json` file in the PR.
DON'T modify any other token on the list.

At minimum each entry should have

- Token Address: 2pMNgs7Arn1oQBNSb65Aj55rY2zpWHV9JkuqK6ZoetCj
- Token Name: KUGLE-BOX
- Token Symbol: KBX
- Logo: https://cdn.jsdelivr.net/gh/Seigneur-Machiavel/kugle.github.io/Tokens/KBX_200.png
- Link to the official homepage of token: https://kugle.org
- Coingecko ID if available (https://www.coingecko.com/api/documentations/v3#/coins/get_coins__id_):
