### PR TITLE
XSB: Remove coingecko id

### DIFF
--- a/src/tokens/solana.tokenlist.json
+++ b/src/tokens/solana.tokenlist.json
@@ -8223,8 +8223,7 @@
       "extensions": {
         "website": "https://solareum.app",
         "telegram": "https://t.me/solareum_wallet",
-        "twitter": "https://twitter.com/solareum_wallet",
-        "coingeckoId": "solareum"
+        "twitter": "https://twitter.com/solareum_wallet"
       }
     },
     {


### PR DESCRIPTION
We would like to update our token information. Since XSB is not available for trading, so we would like to take out coingecko at the moment.