### PR TITLE
Remove NFT tag from FRIES token

### DIFF
--- a/src/tokens/solana.tokenlist.json
+++ b/src/tokens/solana.tokenlist.json
@@ -18547,7 +18547,6 @@
       "decimals": 9,
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/FriCEbw1V99GwrJRXPnSQ6su2TabHabNxiZ3VNsVFPPN/logo.png",
       "tags": [
-        "nft",
         "utility-token"
       ],
       "extensions": {


### PR DESCRIPTION
Since FRIES is a utility token on a NFT project. Our previous mistake on tagging it as nft has caused it to display in "NFT" section in wallet instead of in token. This token is divisible and shall not be classified as NFT for user to transfer.

I know it doesn't going to be automerged because of deletion of one line

But I hope it gets merged by Solana Labs team soon since it seems like we are really struggle from our token not displaying and working properly on Phantom wallet because of that nft tag

I apologize, it was my fault, I thought it's safe to tag our governance token with nft tag since it's highly connected to our NFT project.

Don't want to ping anybody but hope it resolves soon <3


## I agree to not ping _anybody_ on Discord/Twitter/email about this pull request. Instead I will inquire by posting a new comment in the pull request if needed.

---

PRs are reviewed in bulk and and can take up to **two weeks** to be merged.

_This repository is managed using an auto merge action. Please ensure your PR has no deleted lines, and it will be merged._

## **Please provide the following information for your token.**

Please include change to the `src/tokens/solana.tokenlist.json` file in the PR.
DON'T modify any other token on the list.

At minimum each entry should have

- Token Address:
- Token Name:
- Token Symbol:
- Logo: (logo should be uploaded under assets/mainnet/<mint address>/\*.<png/svg>)
- Link to the official homepage of token:
- Coingecko ID if available (https://www.coingecko.com/api/documentations/v3#/coins/get_coins__id_):
