### PR TITLE
correct 20 token definitions' location in dict

### DIFF
--- a/src/tokens/solana.tokenlist.json
+++ b/src/tokens/solana.tokenlist.json
@@ -24603,270 +24603,308 @@
         "twitter": "https://twitter.com/DogelonSol",
         "discord": "https://discord.com/invite/A89B9rsB"
       }
+    },
+    {
+      "chainId": 101,
+      "address": "2kMjMxSLLY3RP1Svg8THnoiAfnaScAemGUhVRF9bYcC7",
+      "symbol": "BPCoin",
+      "decimals": 9,
+      "extensions": {
+        "website": "https://bricks.properties",
+        "instagram": "https://instagram.com/bricksproperties"
+      }
+    },
+    {
+      "chainId": 103,
+      "address": "4p9KCkzJ26JDNsQY6FJHx8wn2N8UtTfA9KNduWEuLN9b",
+      "symbol": "UO",
+      "name": "UOWN Coin",
+      "decimals": 10,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/4p9KCkzJ26JDNsQY6FJHx8wn2N8UtTfA9KNduWEuLN9b/logo.png",
+      "tags": [
+        "stablecoin"
+      ],
+      "extensions": {
+        "website": "https://www.uown.co"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "7zhbkbKpGaUsJW7AD4yyAfGGoy53Xx2H3Ai5BKcwGKHw",
+      "symbol": "BUNNY",
+      "name": "SolBunny",
+      "decimals": 0,
+      "logoURI": "https://raw.githubusercontent.com/BunnyNomics101/token-list/main/assets/mainnet/7zhbkbKpGaUsJW7AD4yyAfGGoy53Xx2H3Ai5BKcwGKHw/logo.png",
+      "tags": [
+        "dao",
+        "meme-token",
+        "Defi",
+        "Gamefi"
+      ],
+      "extensions": {
+        "website": "https://solbunny.io",
+        "discord": "https://discord.gg/h7CZnKCb",
+        "twitter": "https://twitter.com/SolanaBunny"
+      }
+    },
+    {
+      "chainId": 103,
+      "address": "RMRUKEmLrdjYSpd7gxQQ2y4VuFcM8jkanXaDNuMdaCZ",
+      "symbol": "RM",
+      "name": "Ringgit Malaysia",
+      "decimals": 2,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/RMRUKEmLrdjYSpd7gxQQ2y4VuFcM8jkanXaDNuMdaCZ/logo.png",
+      "tags": [
+        "stablecoin",
+        "ringgit",
+        "malaysia"
+      ],
+      "extensions": {
+        "website": "https://ringgit.finance",
+        "twitter": "https://twitter.com/ringgitfinance"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "Bp2vDyLQHE7nfx1e4h4E1mFEeMKk36PnvpXfxxPWm5dZ",
+      "symbol": "SOLPANDS",
+      "name": "SOLPANDS",
+      "decimals": 9,
+      "logoURI": "https://i.ibb.co/m07n4vn/photo-2021-10-30-00-38-55.jpg",
+      "tags": [
+        "meme-token"
+      ],
+      "extensions": {
+        "twitter": "https://twitter.com/SOLPANDS"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "6XWfkyg5mzGtKNftSDgYjyoPyUsLRf2rafj95XSFSFrr",
+      "symbol": "KITTY",
+      "name": "Kitty Coin",
+      "decimals": 6,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/6XWfkyg5mzGtKNftSDgYjyoPyUsLRf2rafj95XSFSFrr/logo.png",
+      "tags": [
+        "meme-token",
+        "kitty",
+        "cat"
+      ],
+      "extensions": {
+        "twitter": "https://twitter.com/KittyCoinSolana"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "FZMcCAq9U65mymBjUxKXPUJehDJMLg54Ud5bTrmbaHYS",
+      "symbol": "DCN",
+      "name": "DoodleCoin",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/FZMcCAq9U65mymBjUxKXPUJehDJMLg54Ud5bTrmbaHYS/logo.png",
+      "tags": [
+        "meme-token"
+      ],
+      "extensions": {
+        "website": "https://doodlecoin.me/"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "DCDUaGKLHcwEXdd2MiUYmW4PFtzCfCxncUZ5UZyGxdqh",
+      "symbol": "KATZ",
+      "name": "MeerkatCoin",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/DCDUaGKLHcwEXdd2MiUYmW4PFtzCfCxncUZ5UZyGxdqh/logo.png",
+      "tags": [
+        "community-token"
+      ],
+      "extensions": {
+        "website": "https://meerkatmillionaires.club",
+        "twitter": "https://twitter.com/mmccsolana",
+        "discord": "https://discord.gg/ynkkE3raZf"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "GCxgQbbvJc4UyqGCsUAUa38npzZX27EMxZwckLuWeEkt",
+      "symbol": "NUTS",
+      "name": "NUTS",
+      "decimals": 9,
+      "logoURI": "https://user-images.githubusercontent.com/93886730/140664862-6dd80bff-be30-4c68-a978-fcb205011d61.png",
+      "tags": [
+        "community-token"
+      ],
+      "extensions": {
+        "website": "https://ssa.gg",
+        "twitter": "https://twitter.com/SSA_NFT",
+        "discord": "https://discord.gg/SSANFT"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "9wPT3uJrH43TPPupYyaywXaaqBNLTxMDGoaAvnz4RMMR",
+      "symbol": "DKC",
+      "name": "DockCoin",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/9wPT3uJrH43TPPupYyaywXaaqBNLTxMDGoaAvnz4RMMR/logo.png",
+      "tags": [
+        "meme-token"
+      ],
+      "extensions": {
+        "website": "https://dockcoin.me/"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "Bo2kpetkHvtdjASpeRRiugzmdFhvbVsCMH6aq4mNd8TL",
+      "symbol": "NETX",
+      "name": "Syncline Health Network",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/Bo2kpetkHvtdjASpeRRiugzmdFhvbVsCMH6aq4mNd8TL/logo.png",
+      "tags": [
+        "utility-token"
+      ],
+      "extensions": {
+        "website": "https://syncline.network",
+        "twitter ": "https://twitter.com/synclinenetwork",
+        "telegram ": "https://t.me/joinchat/SKSLdG0sF53TFK6_"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "6gNNYnBxXccu1PSzFDqhQdNACJNF7TEQc6kPQwZ8Zwv",
+      "symbol": "INK",
+      "name": "Octopus Ink",
+      "decimals": 0,
+      "logoURI": "https://gateway.pinata.cloud/ipfs/QmV6Au6eeGiS4F7qkWaueNDLyx2vV6fs3q67opyzVDKFz6",
+      "tags": [
+        "utility-token"
+      ],
+      "extensions": {
+        "website": "https://socialoctopus.io",
+        "twitter": "https://twitter.com/socialoctopusio",
+        "discord": "https://discord.gg/nSMc9EjvT4"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "Ch9NFVk5sqEPQHtw2gJVgnHfTm7FW1JspYwc7SxLi6q3",
+      "symbol": "MEND",
+      "name": "Mend",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/Ch9NFVk5sqEPQHtw2gJVgnHfTm7FW1JspYwc7SxLi6q3/logo.png",
+      "tags": [
+      ],
+      "extensions": {
+        "website": "https://mend.house",
+        "twitter": "https://twitter.com/mendappinc"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "J9yYvSXrtMV749XAbcFeMFpeY4AFwkFq9WpNDmmfV81Q",
+      "symbol": "POCH",
+      "name": "Poochu Coin",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/J9yYvSXrtMV749XAbcFeMFpeY4AFwkFq9WpNDmmfV81Q/logo.png",
+      "tags": [
+        "stake-pool-token",
+        "utility-token",
+        "meme-token",
+        "community-token"
+      ]
+    },
+    {
+      "chainId": 101,
+      "address": "7YhfUG27m7ceDCBnB48dGy4mAJab2hqi6YKkp9Ho7ybv",
+      "symbol": "BANANA",
+      "name": "Banana Bucks",
+      "decimals": 2,
+      "logoURI": "https://i.ibb.co/DMQNjc0/bananabucks-thumbnail.jpg",
+      "tags": [
+        "meme-token"
+      ],
+      "extensions": {
+        "discord": "https://discord.gg/DVH2ggAc",
+        "twitter": "https://twitter.com/solbananabucks"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "snowRZ1wtHa7eiBhJVUqkyFn8P8zwkmL4UTXU7Zdgbu",
+      "symbol": "SNOW",
+      "name": "Snowflake",
+      "decimals": 6,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/snowRZ1wtHa7eiBhJVUqkyFn8P8zwkmL4UTXU7Zdgbu/logo.png",
+      "tags": [],
+      "extensions": {
+        "website": "https://snowflake.so",
+        "twitter": "https://twitter.com/snowflake_sol"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "inL8PMVd6iiW3RCBJnr5AsrRN6nqr4BTrcNuQWQSkvY",
+      "symbol": "IN",
+      "name": "Sol Invictus",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/inL8PMVd6iiW3RCBJnr5AsrRN6nqr4BTrcNuQWQSkvY/logo-owl.png",
+      "tags": [
+        "decentralized-reserve-currency",
+        "utility-token",
+        "DeFi",
+        "community-token"
+      ],
+      "extensions": {
+        "coingeckoId": "invictus",
+        "website": "https://invictusdao.fi/",
+        "twitter": "https://twitter.com/InvictusDAO",
+        "discord": "http://discord.gg/invictusdao"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "7puG5H5Mc6QpvaXjAVLr6GnL5hhUMnpLcUm8G3mEsgHQ",
+      "symbol": "LEONIDAS",
+      "name": "Leonidas Token",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/7puG5H5Mc6QpvaXjAVLr6GnL5hhUMnpLcUm8G3mEsgHQ/logo.png",
+      "tags": [
+        "community-token",
+        "utility-token",
+        "social-token",
+        "NFTs",
+        "DeFi"
+      ],
+      "extensions": {
+        "telegram": "https://www.t.me/leonidas_token",
+        "website": "https://www.leonidastoken.com",
+        "twitter": "https://www.twitter.com/leonidas_token",
+        "discord": "https://www.discord.com/invite/drN8FUruAu",
+        "instagram": "https://www.instagram.com/leonidas_token",
+        "reddit": "https://www.reddit.com/r/leonidas_token",
+        "medium": "https://leonidastoken.medium.com",
+        "serumV3Usdc": "DTEmm1nC7n8vb3KmVabT6dEEnSNeDXNu1jWN4u2DfD7Z"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "8pMdj3AvCV4EbqRBCHMyDAVeMtBmP4wMhCDXqAtFcAqD",
+      "symbol": "GROOT",
+      "name": "Groot",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/8pMdj3AvCV4EbqRBCHMyDAVeMtBmP4wMhCDXqAtFcAqD/logo.png",
+      "tags": [
+        "meme-token"
+      ],
+      "extensions": {
+        "website": "https://groot.sol/"
+      }
     }
   ],
   "version": {
     "major": 0,
     "minor": 3,
     "patch": 2
-  },
-  "chainId": 101,
-  "address": "2kMjMxSLLY3RP1Svg8THnoiAfnaScAemGUhVRF9bYcC7",
-  "symbol": "BPCoin",
-  "decimals": 9,
-  "extensions": {
-    "website": "https://bricks.properties",
-    "instagram": "https://instagram.com/bricksproperties"
-  },
-  "chainId": 103,
-  "address": "4p9KCkzJ26JDNsQY6FJHx8wn2N8UtTfA9KNduWEuLN9b",
-  "symbol": "UO",
-  "name": "UOWN Coin",
-  "decimals": 10,
-  "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/4p9KCkzJ26JDNsQY6FJHx8wn2N8UtTfA9KNduWEuLN9b/logo.png",
-  "tags": [
-    "stablecoin"
-  ],
-  "extensions": {
-    "website": "https://www.uown.co"
-  },
-  "chainId": 101,
-  "address": "7zhbkbKpGaUsJW7AD4yyAfGGoy53Xx2H3Ai5BKcwGKHw",
-  "symbol": "BUNNY",
-  "name": "SolBunny",
-  "decimals": 0,
-  "logoURI": "https://raw.githubusercontent.com/BunnyNomics101/token-list/main/assets/mainnet/7zhbkbKpGaUsJW7AD4yyAfGGoy53Xx2H3Ai5BKcwGKHw/logo.png",
-  "tags": [
-    "dao",
-    "meme-token",
-    "Defi",
-    "Gamefi"
-  ],
-  "extensions": {
-    "website": "https://solbunny.io",
-    "discord": "https://discord.gg/h7CZnKCb",
-    "twitter": "https://twitter.com/SolanaBunny"
-  },
-  "chainId": 103,
-  "address": "RMRUKEmLrdjYSpd7gxQQ2y4VuFcM8jkanXaDNuMdaCZ",
-  "symbol": "RM",
-  "name": "Ringgit Malaysia",
-  "decimals": 2,
-  "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/RMRUKEmLrdjYSpd7gxQQ2y4VuFcM8jkanXaDNuMdaCZ/logo.png",
-  "tags": [
-    "stablecoin",
-    "ringgit",
-    "malaysia"
-  ],
-  "extensions": {
-    "website": "https://ringgit.finance",
-    "twitter": "https://twitter.com/ringgitfinance"
-  },
-  "chainId": 101,
-  "address": "Bp2vDyLQHE7nfx1e4h4E1mFEeMKk36PnvpXfxxPWm5dZ",
-  "symbol": "SOLPANDS",
-  "name": "SOLPANDS",
-  "decimals": 9,
-  "logoURI": "https://i.ibb.co/m07n4vn/photo-2021-10-30-00-38-55.jpg",
-  "tags": [
-    "meme-token"
-  ],
-  "extensions": {
-    "twitter": "https://twitter.com/SOLPANDS"
-  },
-  "chainId": 101,
-  "address": "6XWfkyg5mzGtKNftSDgYjyoPyUsLRf2rafj95XSFSFrr",
-  "symbol": "KITTY",
-  "name": "Kitty Coin",
-  "decimals": 6,
-  "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/6XWfkyg5mzGtKNftSDgYjyoPyUsLRf2rafj95XSFSFrr/logo.png",
-  "tags": [
-    "meme-token",
-    "kitty",
-    "cat"
-  ],
-  "extensions": {
-    "twitter": "https://twitter.com/KittyCoinSolana"
-  },
-  "chainId": 101,
-  "address": "FZMcCAq9U65mymBjUxKXPUJehDJMLg54Ud5bTrmbaHYS",
-  "symbol": "DCN",
-  "name": "DoodleCoin",
-  "decimals": 9,
-  "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/FZMcCAq9U65mymBjUxKXPUJehDJMLg54Ud5bTrmbaHYS/logo.png",
-  "tags": [
-    "meme-token"
-  ],
-  "extensions": {
-    "website": "https://doodlecoin.me/"
-  },
-  "chainId": 101,
-  "address": "DCDUaGKLHcwEXdd2MiUYmW4PFtzCfCxncUZ5UZyGxdqh",
-  "symbol": "KATZ",
-  "name": "MeerkatCoin",
-  "decimals": 9,
-  "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/DCDUaGKLHcwEXdd2MiUYmW4PFtzCfCxncUZ5UZyGxdqh/logo.png",
-  "tags": [
-    "community-token"
-  ],
-  "extensions": {
-    "website": "https://meerkatmillionaires.club",
-    "twitter": "https://twitter.com/mmccsolana",
-    "discord": "https://discord.gg/ynkkE3raZf"
-  },
-  "chainId": 101,
-  "address": "GCxgQbbvJc4UyqGCsUAUa38npzZX27EMxZwckLuWeEkt",
-  "symbol": "NUTS",
-  "name": "NUTS",
-  "decimals": 9,
-  "logoURI": "https://user-images.githubusercontent.com/93886730/140664862-6dd80bff-be30-4c68-a978-fcb205011d61.png",
-  "tags": [
-    "community-token"
-  ],
-  "extensions": {
-    "website": "https://ssa.gg",
-    "twitter": "https://twitter.com/SSA_NFT",
-    "discord": "https://discord.gg/SSANFT"
-  },
-  "chainId": 101,
-  "address": "9wPT3uJrH43TPPupYyaywXaaqBNLTxMDGoaAvnz4RMMR",
-  "symbol": "DKC",
-  "name": "DockCoin",
-  "decimals": 9,
-  "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/9wPT3uJrH43TPPupYyaywXaaqBNLTxMDGoaAvnz4RMMR/logo.png",
-  "tags": [
-    "meme-token"
-  ],
-  "extensions": {
-    "website": "https://dockcoin.me/"
-  },
-  "chainId": 101,
-  "address": "Bo2kpetkHvtdjASpeRRiugzmdFhvbVsCMH6aq4mNd8TL",
-  "symbol": "NETX",
-  "name": "Syncline Health Network",
-  "decimals": 9,
-  "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/Bo2kpetkHvtdjASpeRRiugzmdFhvbVsCMH6aq4mNd8TL/logo.png",
-  "tags": [
-    "utility-token"
-  ],
-  "extensions": {
-    "website": "https://syncline.network",
-    "twitter ": "https://twitter.com/synclinenetwork",
-    "telegram ": "https://t.me/joinchat/SKSLdG0sF53TFK6_"
-  },
-  "chainId": 101,
-  "address": "6gNNYnBxXccu1PSzFDqhQdNACJNF7TEQc6kPQwZ8Zwv",
-  "symbol": "INK",
-  "name": "Octopus Ink",
-  "decimals": 0,
-  "logoURI": "https://gateway.pinata.cloud/ipfs/QmV6Au6eeGiS4F7qkWaueNDLyx2vV6fs3q67opyzVDKFz6",
-  "tags": [
-    "utility-token"
-  ],
-  "extensions": {
-    "website": "https://socialoctopus.io",
-    "twitter": "https://twitter.com/socialoctopusio",
-    "discord": "https://discord.gg/nSMc9EjvT4"
-  },
-  "chainId": 101,
-  "address": "Ch9NFVk5sqEPQHtw2gJVgnHfTm7FW1JspYwc7SxLi6q3",
-  "symbol": "MEND",
-  "name": "Mend",
-  "decimals": 9,
-  "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/Ch9NFVk5sqEPQHtw2gJVgnHfTm7FW1JspYwc7SxLi6q3/logo.png",
-  "tags": [
-  ],
-  "extensions": {
-    "website": "https://mend.house",
-    "twitter": "https://twitter.com/mendappinc"
-  },
-  "chainId": 101,
-  "address": "J9yYvSXrtMV749XAbcFeMFpeY4AFwkFq9WpNDmmfV81Q",
-  "symbol": "POCH",
-  "name": "Poochu Coin",
-  "decimals": 9,
-  "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/J9yYvSXrtMV749XAbcFeMFpeY4AFwkFq9WpNDmmfV81Q/logo.png",
-  "tags": [
-    "stake-pool-token",
-    "utility-token",
-    "meme-token",
-    "community-token"
-  ],
-  "chainId": 101,
-  "address": "7YhfUG27m7ceDCBnB48dGy4mAJab2hqi6YKkp9Ho7ybv",
-  "symbol": "BANANA",
-  "name": "Banana Bucks",
-  "decimals": 2,
-  "logoURI": "https://i.ibb.co/DMQNjc0/bananabucks-thumbnail.jpg",
-  "tags": [
-    "meme-token"
-  ],
-  "extensions": {
-    "discord": "https://discord.gg/DVH2ggAc",
-    "twitter": "https://twitter.com/solbananabucks"
-  },
-  "chainId": 101,
-  "address": "snowRZ1wtHa7eiBhJVUqkyFn8P8zwkmL4UTXU7Zdgbu",
-  "symbol": "SNOW",
-  "name": "Snowflake",
-  "decimals": 6,
-  "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/snowRZ1wtHa7eiBhJVUqkyFn8P8zwkmL4UTXU7Zdgbu/logo.png",
-  "tags": [],
-  "extensions": {
-    "website": "https://snowflake.so",
-    "twitter": "https://twitter.com/snowflake_sol"
-  },
-  "chainId": 101,
-  "address": "inL8PMVd6iiW3RCBJnr5AsrRN6nqr4BTrcNuQWQSkvY",
-  "symbol": "IN",
-  "name": "Sol Invictus",
-  "decimals": 9,
-  "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/inL8PMVd6iiW3RCBJnr5AsrRN6nqr4BTrcNuQWQSkvY/logo-owl.png",
-  "tags": [
-    "decentralized-reserve-currency",
-    "utility-token",
-    "DeFi",
-    "community-token"
-  ],
-  "extensions": {
-    "coingeckoId": "invictus",
-    "website": "https://invictusdao.fi/",
-    "twitter": "https://twitter.com/InvictusDAO",
-    "discord": "http://discord.gg/invictusdao"
-  },
-  "chainId": 101,
-  "address": "7puG5H5Mc6QpvaXjAVLr6GnL5hhUMnpLcUm8G3mEsgHQ",
-  "symbol": "LEONIDAS",
-  "name": "Leonidas Token",
-  "decimals": 9,
-  "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/7puG5H5Mc6QpvaXjAVLr6GnL5hhUMnpLcUm8G3mEsgHQ/logo.png",
-  "tags": [
-    "community-token",
-    "utility-token",
-    "social-token",
-    "NFTs",
-    "DeFi"
-  ],
-  "extensions": {
-    "telegram": "https://www.t.me/leonidas_token",
-    "website": "https://www.leonidastoken.com",
-    "twitter": "https://www.twitter.com/leonidas_token",
-    "discord": "https://www.discord.com/invite/drN8FUruAu",
-    "instagram": "https://www.instagram.com/leonidas_token",
-    "reddit": "https://www.reddit.com/r/leonidas_token",
-    "medium": "https://leonidastoken.medium.com",
-    "serumV3Usdc": "DTEmm1nC7n8vb3KmVabT6dEEnSNeDXNu1jWN4u2DfD7Z"
-  },
-  "chainId": 101,
-  "address": "8pMdj3AvCV4EbqRBCHMyDAVeMtBmP4wMhCDXqAtFcAqD",
-  "symbol": "GROOT",
-  "name": "Groot",
-  "decimals": 9,
-  "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/8pMdj3AvCV4EbqRBCHMyDAVeMtBmP4wMhCDXqAtFcAqD/logo.png",
-  "tags": [
-    "meme-token"
-  ],
-  "extensions": {
-    "website": "https://groot.sol/"
   }
 }

--- a/src/tokens/solana.tokenlist.json
+++ b/src/tokens/solana.tokenlist.json
@@ -57,7 +57,7 @@
   },
   "timestamp": "2021-03-03T19:57:21+0000",
   "tokens": [
-     {
+    {
       "chainId": 101,
       "address": "BqRtfrNpvRAW3KW319hvhPoTu76wKU2LTdXJyG9CyDze",
       "symbol": "ECHO",
@@ -66,7 +66,7 @@
       "logoURI": "https://i.imgur.com/HnnxQND.png",
       "tags": [
         "utility-token",
-		"DAO-fork"
+        "DAO-fork"
       ],
       "extensions": {
         "serumV3Usdc": "8bjQ8XvzrDxKxHhTccpLkqGLbBrCAAPuv6KHrgN95nDW",
@@ -75,38 +75,39 @@
         "discord": "https://discord.com/invite/NtvVPs4WnY"
       }
     },
-{
-    "chainId": 101,
-    "address": "HCXXtXPasqcF4BVsrPQPfHMQPUofoCbDbjsTUANFSHDR",
-    "symbol": "MONKE",
-    "name": "MONKE TOKEN",
-    "decimals": 9,
-    "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/HCXXtXPasqcF4BVsrPQPfHMQPUofoCbDbjsTUANFSHDR/logo.png",
-    "tags": [
-      "community-token", "meme-token"
-    ],
-    "extensions": {
-      "website": "https://monketoken.xyz/"
-    }
-},
-{
-  "chainId": 101,
-  "address": "GLStmw33pftMX9w1AkMEUhB8pDcWQYw33VopUxJJdHbu",
-  "symbol": "DIBU",
-  "name": "Solana DickButt",
-  "decimals": 3,
-  "logoURI": "https://cdn.jsdelivr.net/gh/xRoBBeRT/DIBU-logo/DickButPhantomLogo.png",
-  "tags": [
-    "community-token",
-    "meme-token"
-  ],
-  "extensions": {
-    "website": "https://solanadickbutt.com",
-    "twitter": "https://twitter.com/SolanaDickButt",
-    "discord": "https://discord.com/invite/solanadickbutt"
-  }
-},
-   {
+    {
+      "chainId": 101,
+      "address": "HCXXtXPasqcF4BVsrPQPfHMQPUofoCbDbjsTUANFSHDR",
+      "symbol": "MONKE",
+      "name": "MONKE TOKEN",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/HCXXtXPasqcF4BVsrPQPfHMQPUofoCbDbjsTUANFSHDR/logo.png",
+      "tags": [
+        "community-token",
+        "meme-token"
+      ],
+      "extensions": {
+        "website": "https://monketoken.xyz/"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "GLStmw33pftMX9w1AkMEUhB8pDcWQYw33VopUxJJdHbu",
+      "symbol": "DIBU",
+      "name": "Solana DickButt",
+      "decimals": 3,
+      "logoURI": "https://cdn.jsdelivr.net/gh/xRoBBeRT/DIBU-logo/DickButPhantomLogo.png",
+      "tags": [
+        "community-token",
+        "meme-token"
+      ],
+      "extensions": {
+        "website": "https://solanadickbutt.com",
+        "twitter": "https://twitter.com/SolanaDickButt",
+        "discord": "https://discord.com/invite/solanadickbutt"
+      }
+    },
+    {
       "chainId": 101,
       "address": "6JdcMdhqgCtcP4U9tieRqmKLhPLxRMLC67QfmdXAJBvZ",
       "symbol": "KITTY",
@@ -123,7 +124,7 @@
         "discord": "https://discord.gg/XaRfbtsscz"
       }
     },
-   {
+    {
       "chainId": 101,
       "address": "HDiA4quoMibAGeJQzvxajp3Z9cvnkNng99oVrnuNj6px",
       "symbol": "KSAMO",
@@ -138,37 +139,38 @@
         "twitter": "https://twitter.com/TokenKingSamo"
       }
     },
-{
-  "chainId": 101,
-  "address": "73YQDsoPB3t5n5GqX53tKrwJK1n6HCZ935MEbo2gEYU5",
-  "symbol": "KAJAME",
-  "name": "Kajame",
-  "decimals": 4,
-  "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/73YQDsoPB3t5n5GqX53tKrwJK1n6HCZ935MEbo2gEYU5/logo.png",
-  "tags": [
-    "meme-token",
-    "social-token",
-    "community-token"
-  ],
-  "extensions": {
-    "blog": "https://blog.me-idea.in.th",
-    "website": "https://kajame.xyz"
-  }
-},
-{
-    "chainId": 101,
-    "address": "DJKX1cX2SPPaTdYBeuriUeQUUEpi2UGBGGPQthNMrgaa",
-    "symbol": "MONKE",
-    "name": "MONKE TOKEN",
-    "decimals": 9,
-    "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/DJKX1cX2SPPaTdYBeuriUeQUUEpi2UGBGGPQthNMrgaa/logo.png",
-    "tags": [
-      "community-token", "meme-token"
-    ],
-    "extensions": {
-      "website": "https://monketoken.xyz/"
-    }
-},
+    {
+      "chainId": 101,
+      "address": "73YQDsoPB3t5n5GqX53tKrwJK1n6HCZ935MEbo2gEYU5",
+      "symbol": "KAJAME",
+      "name": "Kajame",
+      "decimals": 4,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/73YQDsoPB3t5n5GqX53tKrwJK1n6HCZ935MEbo2gEYU5/logo.png",
+      "tags": [
+        "meme-token",
+        "social-token",
+        "community-token"
+      ],
+      "extensions": {
+        "blog": "https://blog.me-idea.in.th",
+        "website": "https://kajame.xyz"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "DJKX1cX2SPPaTdYBeuriUeQUUEpi2UGBGGPQthNMrgaa",
+      "symbol": "MONKE",
+      "name": "MONKE TOKEN",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/DJKX1cX2SPPaTdYBeuriUeQUUEpi2UGBGGPQthNMrgaa/logo.png",
+      "tags": [
+        "community-token",
+        "meme-token"
+      ],
+      "extensions": {
+        "website": "https://monketoken.xyz/"
+      }
+    },
     {
       "chainId": 101,
       "address": "6TgvYd7eApfcZ7K5Mur7MaUQ2xT7THB4cLHWuMkQdU5Z",
@@ -177,13 +179,13 @@
       "decimals": 9,
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/6TgvYd7eApfcZ7K5Mur7MaUQ2xT7THB4cLHWuMkQdU5Z.png",
       "tags": [
-		"meme-token"
-	  ],
+        "meme-token"
+      ],
       "extensions": {
         "serumV3Usdc": "4k4WXdmrWjCG71E4pxMs6SQRRB5cypGNYatKb2iMnqN4",
         "website": "http:/www.otterfinance.site",
         "twitter": "https://twitter.com/otter_finance",
-		"discord": "https://discord.gg/chfgc9wxnw"
+        "discord": "https://discord.gg/chfgc9wxnw"
       }
     },
     {
@@ -194,12 +196,12 @@
       "decimals": 6,
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/382HfaEjcUNhwoGbYmL58DVX8GUvjrXiTPchCWKjchWA.png",
       "tags": [
-		"meme-token"
-	  ],
+        "meme-token"
+      ],
       "extensions": {
         "website": "https://www.sheeplana.online/",
         "twitter": "https://twitter.com/sheeplana_coin",
-		"discord": "https://discord.gg/zV9dyHfxGb"
+        "discord": "https://discord.gg/zV9dyHfxGb"
       }
     },
     {
@@ -222,63 +224,64 @@
       "decimals": 9,
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/2mDJPcvv7vigZo9ZPxhHLpKQSixCkbohVY35eX6NkN6m/logo.png",
       "tags": [
-		"meme-token"
-	  ],
+        "meme-token"
+      ],
       "extensions": {
         "serumV3Usdc": "DoL5SXaax9LwQM9JfqFBymiUfSxH9A9cwPugPuHvNTDM",
         "twitter": "https://twitter.com/TokenBook_tbk"
       }
     },
-{
-  "chainId": 101,
-  "address": "DcvJP16Cw5oqTbtHmpJ4JGXaqBvV5m6eMZj5rGsFLpwU",
-  "symbol": "BOOGI",
-  "name": "BABY OOGI",
-  "decimals": 4,
-  "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/DcvJP16Cw5oqTbtHmpJ4JGXaqBvV5m6eMZj5rGsFLpwU/logo.png",
-  "tags": [
-    "community-token", "meme-token"
-  ],
-  "extensions": {
-    "website": "https://babyoogi.xyz/",
-    "twitter": "https://twitter.com/babyoogi_"
-  }
-},
-  {
-    "chainId": 101,
-    "address": "48iGP5MUTZ8DCfDvZ9dpgKySP2iekQ3zPKZM8AhDjEmw",
-    "symbol": "VIRAL",
-    "name": "Viraverse",
-    "decimals": 6,
-    "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/48iGP5MUTZ8DCfDvZ9dpgKySP2iekQ3zPKZM8AhDjEmw/logo.png",
-    "tags": [
-      "stake-pool-token",
-      "utility-token",
-      "security-token",
-      "community-token",
-      "viraverse"
-    ],
-    "extensions": {
-      "website": "https://viraverse.io",
-      "twitter": "https://twitter.com/viraverseio",
-      "telegram": "https://t.me/viraverseio",
-      "discord": "https://discord.gg/EwVdMYvEgV"
-    }
-  },
-  {
-  "chainId": 101,
-  "address": "2WnVfjtW9QttRwqxn3RPnHBFHMR3cyA5Ca3zug41Q9Xb",
-  "symbol": "HNI",
-  "name": "Golden Techie Hannibal Token",
-  "decimals": 0,
-  "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/2WnVfjtW9QttRwqxn3RPnHBFHMR3cyA5Ca3zug41Q9Xb/logo.png",
-  "tags": [
-    "social-token"
-  ],
-  "extensions": {
-    "website": "https://crpanadasoft.com"
-  }
-},
+    {
+      "chainId": 101,
+      "address": "DcvJP16Cw5oqTbtHmpJ4JGXaqBvV5m6eMZj5rGsFLpwU",
+      "symbol": "BOOGI",
+      "name": "BABY OOGI",
+      "decimals": 4,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/DcvJP16Cw5oqTbtHmpJ4JGXaqBvV5m6eMZj5rGsFLpwU/logo.png",
+      "tags": [
+        "community-token",
+        "meme-token"
+      ],
+      "extensions": {
+        "website": "https://babyoogi.xyz/",
+        "twitter": "https://twitter.com/babyoogi_"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "48iGP5MUTZ8DCfDvZ9dpgKySP2iekQ3zPKZM8AhDjEmw",
+      "symbol": "VIRAL",
+      "name": "Viraverse",
+      "decimals": 6,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/48iGP5MUTZ8DCfDvZ9dpgKySP2iekQ3zPKZM8AhDjEmw/logo.png",
+      "tags": [
+        "stake-pool-token",
+        "utility-token",
+        "security-token",
+        "community-token",
+        "viraverse"
+      ],
+      "extensions": {
+        "website": "https://viraverse.io",
+        "twitter": "https://twitter.com/viraverseio",
+        "telegram": "https://t.me/viraverseio",
+        "discord": "https://discord.gg/EwVdMYvEgV"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "2WnVfjtW9QttRwqxn3RPnHBFHMR3cyA5Ca3zug41Q9Xb",
+      "symbol": "HNI",
+      "name": "Golden Techie Hannibal Token",
+      "decimals": 0,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/2WnVfjtW9QttRwqxn3RPnHBFHMR3cyA5Ca3zug41Q9Xb/logo.png",
+      "tags": [
+        "social-token"
+      ],
+      "extensions": {
+        "website": "https://crpanadasoft.com"
+      }
+    },
     {
       "chainId": 101,
       "address": "CgbJxXyaHeU8VsquBpySuFXA94b6LWXxioZ28wRr8fs9",
@@ -299,156 +302,171 @@
         "discord": "https://discord.gg/zpJ7zADRZ5"
       }
     },
-    
     {
       "chainId": 101,
       "address": "6bLp99VoqKU1C3Qp6VTNvSoCoc78jMGxPkGSSopq8wHB",
-      "symbol":"Paws",
+      "symbol": "Paws",
       "name": "Solana Paws",
       "decimals": 2,
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/6bLp99VoqKU1C3Qp6VTNvSoCoc78jMGxPkGSSopq8wHB/logo.png",
-      "tags": ["meme coin", "community", "doge", "Paws" ],
+      "tags": [
+        "meme coin",
+        "community",
+        "doge",
+        "Paws"
+      ],
       "extensions": {
         "website": " https://www.solpaws.com",
         "twitter": "https://twitter.com/Sol_Paws",
         "discord": "https://discord.gg/sVP35wfPhX"
       }
     },
-{
-    "chainId": 101,
-    "address": "GGupQCMnyEmHKcqFu72qCTm6yEYpVyhouY9dSAMEXLsC",
-    "symbol": "DOGEC",
-    "name": "Dogecoin Cash",
-    "decimals": 9,
-    "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/GGupQCMnyEmHKcqFu72qCTm6yEYpVyhouY9dSAMEXLsC/logo.png",
-    "tags": [
-    "community-token", "meme-token", "doge","dogecoin"
-    ],
-    "extensions": {
-	
-    }
-   }
-   ,
-{
-    "chainId": 101,
-    "address": "2d9LcdAQCnxPHSca6frjQzYKapNzB7caSuLKpeWBctvT",
-    "symbol": "Taboo",
-    "name": "TABOO TOKEN",
-    "decimals": 9,
-    "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/2d9LcdAQCnxPHSca6frjQzYKapNzB7caSuLKpeWBctvT/logo.png",
-    "tags": [
-    "community-token", "Taboo-token", "Taboo","Videos"
-    ],
-    "extensions": {
-	
-    }
-   }
-   ,
-{
-    "chainId": 101,
-    "address": "CrhUSH7FDwB37BYvPsVnVbsGVeE81biBzfkD4A4fyJMv",
-    "symbol": "Vikings",
-    "name": "Viking Legend",
-    "decimals": 9,
-    "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/CrhUSH7FDwB37BYvPsVnVbsGVeE81biBzfkD4A4fyJMv/logo.png",
-    "tags": [
-    "community-token", "viking-token", "floki","nfts"
-    ],
-    "extensions": {
-	
-    }
-   }
-   ,
-{
-    "chainId": 101,
-    "address": "3BYQt5MtdUSDkGwPa7F5pxFNx6csyUK2zAqNgoAsQ96h",
-    "symbol": "VIKINGxFLOKI",
-    "name": "VIKINGxFLOKI",
-    "decimals": 9,
-    "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/3BYQt5MtdUSDkGwPa7F5pxFNx6csyUK2zAqNgoAsQ96h/logo.png",
-    "tags": [
-    "community-token", "viking-token", "viking floki","nfts"
-    ],
-    "extensions": {
-	
-    }
-   }
-   ,
-{
-    "chainId": 101,
-    "address": "zWxLppNEHinqYbQffzp2T5yNXUzyQUsHZ39nxjTqk6F",
-    "symbol": "METAS",
-    "name": "Meta Syndrome",
-    "decimals": 9,
-    "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/zWxLppNEHinqYbQffzp2T5yNXUzyQUsHZ39nxjTqk6F/logo.png",
-    "tags": [
-    "community-token", "meta-token", "meta mark","nfts"
-    ],
-    "extensions": {
-	
-    }
-   }
-   ,
-{
-    "chainId": 101,
-    "address": "8sMa1Jfcpt2eSkKDtcd6rurX27gqxkrEvXn5jHt3suGB",
-    "symbol": "DGMOON",
-    "name": "DogeMoonxSOL",
-    "decimals": 9,
-    "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/8sMa1Jfcpt2eSkKDtcd6rurX27gqxkrEvXn5jHt3suGB/logo.png",
-    "tags": [
-    "community-token", "doge-token", "doge","nfts"
-    ],
-    "extensions": {
-	
-    }
-   }
-   ,
-{
-    "chainId": 101,
-    "address": "8g9kLFgtHF4kMVjGbpnPNUU8QbxMHpLZTKhAJyvwr9on",
-    "symbol": "MCAT",
-    "name": "Meta Cat",
-    "decimals": 9,
-    "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/8g9kLFgtHF4kMVjGbpnPNUU8QbxMHpLZTKhAJyvwr9on/logo.png",
-    "tags": [
-    "community-token", "cat-token", "cat","nfts", "meta" , "Facebook"
-    ],
-    "extensions": {
-	
-    }
-   }
-   ,
-{
-    "chainId": 101,
-    "address": "H5TA9LexsmmvLM49zdEkbaPCcHJed8TTFtRqny81tEaK",
-    "symbol": "xVideos",
-    "name": "xVideo Token",
-    "decimals": 9,
-    "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/H5TA9LexsmmvLM49zdEkbaPCcHJed8TTFtRqny81tEaK/logo.png",
-    "tags": [
-    "community-token", "platform", "videos","payment"
-    ],
-    "extensions": {
-	
-    }
-   }
-   ,
-{
-    "chainId": 101,
-    "address": "roCKojKezC7HhPxph5qb4UBasvmZJWgegCF57PvaV2f",
-    "symbol": "ROCK",
-    "name": "RockDeFi",
-    "decimals": 6,
-    "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/roCKojKezC7HhPxph5qb4UBasvmZJWgegCF57PvaV2f/logo.png",
-    "tags": [
-      "stablecoin", "asset"
-    ],
-    "extensions": {
-      "website": "https://rockdefi.app/"
-    }
-  },
-  {
+    {
+      "chainId": 101,
+      "address": "GGupQCMnyEmHKcqFu72qCTm6yEYpVyhouY9dSAMEXLsC",
+      "symbol": "DOGEC",
+      "name": "Dogecoin Cash",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/GGupQCMnyEmHKcqFu72qCTm6yEYpVyhouY9dSAMEXLsC/logo.png",
+      "tags": [
+        "community-token",
+        "meme-token",
+        "doge",
+        "dogecoin"
+      ],
+      "extensions": {
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "2d9LcdAQCnxPHSca6frjQzYKapNzB7caSuLKpeWBctvT",
+      "symbol": "Taboo",
+      "name": "TABOO TOKEN",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/2d9LcdAQCnxPHSca6frjQzYKapNzB7caSuLKpeWBctvT/logo.png",
+      "tags": [
+        "community-token",
+        "Taboo-token",
+        "Taboo",
+        "Videos"
+      ],
+      "extensions": {
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "CrhUSH7FDwB37BYvPsVnVbsGVeE81biBzfkD4A4fyJMv",
+      "symbol": "Vikings",
+      "name": "Viking Legend",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/CrhUSH7FDwB37BYvPsVnVbsGVeE81biBzfkD4A4fyJMv/logo.png",
+      "tags": [
+        "community-token",
+        "viking-token",
+        "floki",
+        "nfts"
+      ],
+      "extensions": {
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "3BYQt5MtdUSDkGwPa7F5pxFNx6csyUK2zAqNgoAsQ96h",
+      "symbol": "VIKINGxFLOKI",
+      "name": "VIKINGxFLOKI",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/3BYQt5MtdUSDkGwPa7F5pxFNx6csyUK2zAqNgoAsQ96h/logo.png",
+      "tags": [
+        "community-token",
+        "viking-token",
+        "viking floki",
+        "nfts"
+      ],
+      "extensions": {
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "zWxLppNEHinqYbQffzp2T5yNXUzyQUsHZ39nxjTqk6F",
+      "symbol": "METAS",
+      "name": "Meta Syndrome",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/zWxLppNEHinqYbQffzp2T5yNXUzyQUsHZ39nxjTqk6F/logo.png",
+      "tags": [
+        "community-token",
+        "meta-token",
+        "meta mark",
+        "nfts"
+      ],
+      "extensions": {
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "8sMa1Jfcpt2eSkKDtcd6rurX27gqxkrEvXn5jHt3suGB",
+      "symbol": "DGMOON",
+      "name": "DogeMoonxSOL",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/8sMa1Jfcpt2eSkKDtcd6rurX27gqxkrEvXn5jHt3suGB/logo.png",
+      "tags": [
+        "community-token",
+        "doge-token",
+        "doge",
+        "nfts"
+      ],
+      "extensions": {
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "8g9kLFgtHF4kMVjGbpnPNUU8QbxMHpLZTKhAJyvwr9on",
+      "symbol": "MCAT",
+      "name": "Meta Cat",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/8g9kLFgtHF4kMVjGbpnPNUU8QbxMHpLZTKhAJyvwr9on/logo.png",
+      "tags": [
+        "community-token",
+        "cat-token",
+        "cat",
+        "nfts",
+        "meta",
+        "Facebook"
+      ],
+      "extensions": {
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "H5TA9LexsmmvLM49zdEkbaPCcHJed8TTFtRqny81tEaK",
+      "symbol": "xVideos",
+      "name": "xVideo Token",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/H5TA9LexsmmvLM49zdEkbaPCcHJed8TTFtRqny81tEaK/logo.png",
+      "tags": [
+        "community-token",
+        "platform",
+        "videos",
+        "payment"
+      ],
+      "extensions": {
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "roCKojKezC7HhPxph5qb4UBasvmZJWgegCF57PvaV2f",
+      "symbol": "ROCK",
+      "name": "RockDeFi",
+      "decimals": 6,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/roCKojKezC7HhPxph5qb4UBasvmZJWgegCF57PvaV2f/logo.png",
+      "tags": [
+        "stablecoin",
+        "asset"
+      ],
+      "extensions": {
+        "website": "https://rockdefi.app/"
+      }
+    },
+    {
       "chainId": 101,
       "address": "FeGm2DB4EWHm2LS8ABnRatzARDRYFyUPkLsSJkJwBuSu",
       "symbol": "FKM",
@@ -457,7 +475,7 @@
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/FeGm2DB4EWHm2LS8ABnRatzARDRYFyUPkLsSJkJwBuSu/logo.png",
       "tags": [
         "wrapped",
-		"wormhole"
+        "wormhole"
       ],
       "extensions": {
         "address": "0xc999f49bb48179d5df09402a4a7a4034bc039f81",
@@ -465,52 +483,55 @@
         "assetContract": "https://bscscan.com/address/0xc999f49bb48179d5df09402a4a7a4034bc039f81",
         "website": "https://flokimuskweb.com",
         "twitter": "https://twitter.com/flokimuskmeme"
-    }
-  },
-  {
-    "chainId": 101,
-    "address": "usdrQqxAGgWsBRzzcckAi9ZAzHp19rFCNn87p4Q8Eir",
-    "symbol": "USDR",
-    "name": "RockDeFi Stablecoin",
-    "decimals": 6,
-    "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/usdrQqxAGgWsBRzzcckAi9ZAzHp19rFCNn87p4Q8Eir/logo.png",
-    "tags": [
-      "stablecoin", "asset"
-    ],
-    "extensions": {
-      "website": "https://rockdefi.app/"
-    }
-  },
-  {
-    "chainId": 101,
-    "address": "9cU8yLEAidMNVGEq6QHPe2ktN7SV2qqvLABth8YiSwYx",
-    "symbol": "PARM",
-    "name": "Parm Coin",
-    "decimals": 6,
-    "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/9cU8yLEAidMNVGEq6QHPe2ktN7SV2qqvLABth8YiSwYx/logo.png",
-    "tags": [
-      "community-token", "meme-token"
-    ],
-    "extensions": {
-      "twitter": "https://twitter.com/theeggplantNFT",
-      "website": "https://www.eggplantparty.com"
-    }
-  },
-  {
-    "chainId": 101,
-    "address": "A9Nc6Yo9YGKsaeAb2nsQFSQpLcdotGqjEJmEQFzZeeqX",
-    "symbol": "GM",
-    "name": "Good Morning Coin",
-    "decimals": 9,
-    "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/A9Nc6Yo9YGKsaeAb2nsQFSQpLcdotGqjEJmEQFzZeeqX/logo.png",
-    "tags": [
-      "meme-token", "community-token"
-    ],
-    "extensions": {
-      "website": "https://goodmorning.money"
-    }
-  },
-  {
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "usdrQqxAGgWsBRzzcckAi9ZAzHp19rFCNn87p4Q8Eir",
+      "symbol": "USDR",
+      "name": "RockDeFi Stablecoin",
+      "decimals": 6,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/usdrQqxAGgWsBRzzcckAi9ZAzHp19rFCNn87p4Q8Eir/logo.png",
+      "tags": [
+        "stablecoin",
+        "asset"
+      ],
+      "extensions": {
+        "website": "https://rockdefi.app/"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "9cU8yLEAidMNVGEq6QHPe2ktN7SV2qqvLABth8YiSwYx",
+      "symbol": "PARM",
+      "name": "Parm Coin",
+      "decimals": 6,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/9cU8yLEAidMNVGEq6QHPe2ktN7SV2qqvLABth8YiSwYx/logo.png",
+      "tags": [
+        "community-token",
+        "meme-token"
+      ],
+      "extensions": {
+        "twitter": "https://twitter.com/theeggplantNFT",
+        "website": "https://www.eggplantparty.com"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "A9Nc6Yo9YGKsaeAb2nsQFSQpLcdotGqjEJmEQFzZeeqX",
+      "symbol": "GM",
+      "name": "Good Morning Coin",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/A9Nc6Yo9YGKsaeAb2nsQFSQpLcdotGqjEJmEQFzZeeqX/logo.png",
+      "tags": [
+        "meme-token",
+        "community-token"
+      ],
+      "extensions": {
+        "website": "https://goodmorning.money"
+      }
+    },
+    {
       "chainId": 101,
       "address": "AMp8Jo18ZjK2tuQGfjKAkkWnVP4NWX5sav4NJH6pXF2D",
       "symbol": "ASTRA",
@@ -518,19 +539,18 @@
       "decimals": 9,
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/AMp8Jo18ZjK2tuQGfjKAkkWnVP4NWX5sav4NJH6pXF2D/logo.png",
       "tags": [
-      "Launchpad",
-      "NFT"
+        "Launchpad",
+        "NFT"
       ],
       "extensions": {
         "website": "https://astrapad.io/",
-		"twitter": "https://twitter.com/astrapadio",
-		"coingeckoId": "astrapad",
+        "twitter": "https://twitter.com/astrapadio",
+        "coingeckoId": "astrapad",
         "telegram": "https://t.me/AstraPadANN",
         "twitter": "https://twitter.com/AstraPad"
-        
       }
     },
-	{
+    {
       "chainId": 101,
       "address": "45u9AsJtN2KkYpH6GCXtwuoDF7HwgMjTQ84xfH6SJYQy",
       "symbol": "PUT",
@@ -538,71 +558,82 @@
       "decimals": 10,
       "logoURI": "https://cdn.jsdelivr.net/gh/devdutt6/PedalsUpToken/Pedals/pedals.png",
       "tags": [
-      "personal",
-      "development"
+        "personal",
+        "development"
       ],
       "extensions": {
         "website": "https://pedalsup.com/"
       }
     },
     {
-    "chainId": 101,
-    "address": "2kzNeq9Yc6rghrgSfat3cvBkmK9JiePaLv7B4r1YKGDX",
-    "symbol": "FUTT",
-    "name": "Futtbucks",
-    "decimals": 9,
-    "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/2kzNeq9Yc6rghrgSfat3cvBkmK9JiePaLv7B4r1YKGDX/logo.png",
-    "tags": ["community-token", "currency"],
-    "extensions": {
-      "website": "https://futtbucks.com/",
-      "instagram": "https://www.instagram.com/futt.bucks/"
-    }
-  },
-{
-    "chainId": 101,
-    "address": "DE3Tv7eWpXGanVQC9RW1P9RG6AHWtC8VgYS9hRRVcF93",
-    "symbol": "FUTT",
-    "name": "Futtbucks",
-    "decimals": 9,
-    "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/2kzNeq9Yc6rghrgSfat3cvBkmK9JiePaLv7B4r1YKGDX/logo.png",
-    "tags": ["community-token", "currency"],
-    "extensions": {
-      "website": "https://futtbucks.com/",
-      "instagram": "https://www.instagram.com/futt.bucks/"
-    }
-  },
-    {
-        "chainId": 101,
-        "address": "6SKogZxCWY9jKsKPMT3ChJUhQxAEeB6NjVidXQK6TEdW",
-        "symbol": "GDoge",
-        "name": "Golden Doge Solana",
-        "decimals": 1,
-        "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/6SKogZxCWY9jKsKPMT3ChJUhQxAEeB6NjVidXQK6TEdW/Logo.png",
-        "tags": [
-        "community-token", "meme-token", "doge","dogecoin", "shiba inu", "Golden Doge"
-        ],
-        "extensions": {
-          "twitter": "https://twitter.com/GoldSolDoge",
-          "website": "https://http://www.goldsoldoge.com/"
-        }
+      "chainId": 101,
+      "address": "2kzNeq9Yc6rghrgSfat3cvBkmK9JiePaLv7B4r1YKGDX",
+      "symbol": "FUTT",
+      "name": "Futtbucks",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/2kzNeq9Yc6rghrgSfat3cvBkmK9JiePaLv7B4r1YKGDX/logo.png",
+      "tags": [
+        "community-token",
+        "currency"
+      ],
+      "extensions": {
+        "website": "https://futtbucks.com/",
+        "instagram": "https://www.instagram.com/futt.bucks/"
+      }
     },
-{
-	"chainId": 101,
-    	"address": "FaiPGacTM7YBmacumbg4ZnDx7sKtGcG3LkcVoqfddEA7",
-    	"symbol": "BULL",
-    	"name": "theBULL Coin",
-    	"decimals": 0,
-    	"logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/FaiPGacTM7YBmacumbg4ZnDx7sKtGcG3LkcVoqfddEA7/logo.png",
-    	"tags": [
-    		"community-token", 
-		"meme-token", 
-		"NFT"
-		],
-    	"extensions": {
-      		"twitter": "https://twitter.com/theBULL_NFT",
-      		"discord": "https://discord.com/invite/B6sd88UVmD"
-	}
-},
+    {
+      "chainId": 101,
+      "address": "DE3Tv7eWpXGanVQC9RW1P9RG6AHWtC8VgYS9hRRVcF93",
+      "symbol": "FUTT",
+      "name": "Futtbucks",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/2kzNeq9Yc6rghrgSfat3cvBkmK9JiePaLv7B4r1YKGDX/logo.png",
+      "tags": [
+        "community-token",
+        "currency"
+      ],
+      "extensions": {
+        "website": "https://futtbucks.com/",
+        "instagram": "https://www.instagram.com/futt.bucks/"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "6SKogZxCWY9jKsKPMT3ChJUhQxAEeB6NjVidXQK6TEdW",
+      "symbol": "GDoge",
+      "name": "Golden Doge Solana",
+      "decimals": 1,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/6SKogZxCWY9jKsKPMT3ChJUhQxAEeB6NjVidXQK6TEdW/Logo.png",
+      "tags": [
+        "community-token",
+        "meme-token",
+        "doge",
+        "dogecoin",
+        "shiba inu",
+        "Golden Doge"
+      ],
+      "extensions": {
+        "twitter": "https://twitter.com/GoldSolDoge",
+        "website": "https://http://www.goldsoldoge.com/"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "FaiPGacTM7YBmacumbg4ZnDx7sKtGcG3LkcVoqfddEA7",
+      "symbol": "BULL",
+      "name": "theBULL Coin",
+      "decimals": 0,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/FaiPGacTM7YBmacumbg4ZnDx7sKtGcG3LkcVoqfddEA7/logo.png",
+      "tags": [
+        "community-token",
+        "meme-token",
+        "NFT"
+      ],
+      "extensions": {
+        "twitter": "https://twitter.com/theBULL_NFT",
+        "discord": "https://discord.com/invite/B6sd88UVmD"
+      }
+    },
     {
       "chainId": 101,
       "address": "2XSuy8RSESbtYRBbVHxGWuoikn3B6iXKVKzN4i3owTCf",
@@ -618,25 +649,23 @@
         "discord": "https://discord.link/BuffSamo",
         "twitter": "https://twitter.com/buffsamo"
       }
-  },
-  {
-"chainId": 101,
-"address": "DNmxHPgeVLSofyAriirHybKoNx1baM2ufiHKs1W7YyPc",
-"symbol": "RPN",
-"name": "RoyalPangolins",
-"decimals": 9,
-"logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/DNmxHPgeVLSofyAriirHybKoNx1baM2ufiHKs1W7YyPc/logo.png",
-"tags": [
-
-  ],
-  "extensions": {
-    "website": "https://royalpangolins.io/",
-    "Discord": "https://discord.gg/XvjxsRzK",
-    "twitter": "https://twitter.com/RoyalPangolins"
-    
-  }
-},
-  {
+    },
+    {
+      "chainId": 101,
+      "address": "DNmxHPgeVLSofyAriirHybKoNx1baM2ufiHKs1W7YyPc",
+      "symbol": "RPN",
+      "name": "RoyalPangolins",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/DNmxHPgeVLSofyAriirHybKoNx1baM2ufiHKs1W7YyPc/logo.png",
+      "tags": [
+      ],
+      "extensions": {
+        "website": "https://royalpangolins.io/",
+        "Discord": "https://discord.gg/XvjxsRzK",
+        "twitter": "https://twitter.com/RoyalPangolins"
+      }
+    },
+    {
       "chainId": 101,
       "address": "FdnEZ71hjabwo6Eo6XHGyK4QrE1tVQtBoTGMmgWYAuDn",
       "symbol": "GDoge",
@@ -644,45 +673,49 @@
       "decimals": 6,
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/FdnEZ71hjabwo6Eo6XHGyK4QrE1tVQtBoTGMmgWYAuDn/logo.png",
       "tags": [
-      "community-token", "meme-token", "doge","dogecoin", "shiba inu", "Golden Doge"
+        "community-token",
+        "meme-token",
+        "doge",
+        "dogecoin",
+        "shiba inu",
+        "Golden Doge"
       ],
       "extensions": {
         "twitter": "https://twitter.com/GoldSolDoge",
         "website": "https://http://www.goldsoldoge.com/"
       }
-  },
-	{
-	  "chainId": 101,
-	  "address": "4eG64sB6SpvXve4WoRAN956UFKoETLP4JDyMU51TMdep",
-	  "symbol": "WZWT",
-	  "name": "WIZ WIT Token",
-	  "decimals": 9,
-	  "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/4eG64sB6SpvXve4WoRAN956UFKoETLP4JDyMU51TMdep/logo.png",
-	  "tags": [
-		"meme-token"
-	  ],
-	  "extensions": {
-		"website": "https://phillytoken.com",
-		"twitter": "https://twitter.com/phillytoken",
-		"discord": "https://discord.gg/ptYZPtxZf4",
-		"description": "The world's 1st cheesesteak-based currency, brought to you by the City of Brotherly Love (Philly!!!)."
-	  }
-	},
-	{
-		"chainId": 101,
-		"address": "Bjgh4YsLdicr8WArz9ftdSmpWNcQjsZ9KV3w9fkjiLG",
-		"symbol": "SOLRC",
-		"name": "SolRaca",
-		"decimals": 8,
-		"logoURI": "https://raw.githubusercontent.com/Solraca/token-list/main/assets/mainnet/Bjgh4YsLdicr8WArz9ftdSmpWNcQjsZ9KV3w9fkjiLG/solraca.png",
-		"tags": [
-		"meme-token"
-		],
-		"extensions": {
-			"telegram": "https://t.me/solracaofficial"
-			
-		}
-	},
+    },
+    {
+      "chainId": 101,
+      "address": "4eG64sB6SpvXve4WoRAN956UFKoETLP4JDyMU51TMdep",
+      "symbol": "WZWT",
+      "name": "WIZ WIT Token",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/4eG64sB6SpvXve4WoRAN956UFKoETLP4JDyMU51TMdep/logo.png",
+      "tags": [
+        "meme-token"
+      ],
+      "extensions": {
+        "website": "https://phillytoken.com",
+        "twitter": "https://twitter.com/phillytoken",
+        "discord": "https://discord.gg/ptYZPtxZf4",
+        "description": "The world's 1st cheesesteak-based currency, brought to you by the City of Brotherly Love (Philly!!!)."
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "Bjgh4YsLdicr8WArz9ftdSmpWNcQjsZ9KV3w9fkjiLG",
+      "symbol": "SOLRC",
+      "name": "SolRaca",
+      "decimals": 8,
+      "logoURI": "https://raw.githubusercontent.com/Solraca/token-list/main/assets/mainnet/Bjgh4YsLdicr8WArz9ftdSmpWNcQjsZ9KV3w9fkjiLG/solraca.png",
+      "tags": [
+        "meme-token"
+      ],
+      "extensions": {
+        "telegram": "https://t.me/solracaofficial"
+      }
+    },
     {
       "chainId": 101,
       "address": "45HfvXJHY9msY2i4EmUpume1mSMLUvdaWsJRbctAobQM",
@@ -699,50 +732,50 @@
         "twitter": "https://twitter.com/inumonster"
       }
     },
-	{
-		"chainId": 101,
-		"address": "FEYFyLCFLcBNfSuaf2eXNvyY5Jpii7zg9X48Br5vyenG",
-		"symbol": "SUSDT",
-		"name": "Stether",
-		"decimals": 2,
-		"logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/FEYFyLCFLcBNfSuaf2eXNvyY5Jpii7zg9X48Br5vyenG/logo.png",
-		"tags": [
-		"stablecoin"
-		],
-		"extensions": {
-			"website": "https://stether.io/"
-		}
-	},
-	{
-		"chainId": 102,
-		"address": "8ZY7EkwN7LxifYvvrQDbpjqxkrjHUFMwWgq8fupNNvub",
-		"symbol": "BIAD",
-		"name": "daib test token",
-		"decimals": 6,
-		"logoURI": "https://s3.us-west-2.amazonaws.com/secure.notion-static.com/02242929-14bc-4204-ac71-56d855a07078/512_daia.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAT73L2G45O3KS52Y5%2F20211104%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20211104T051518Z&X-Amz-Expires=86400&X-Amz-Signature=df1424dcb1be408faa45ef6af1f7769edf977da365822e00c34a2150167bfe58&X-Amz-SignedHeaders=host&response-content-disposition=filename%20%3D%22512_daia.png%22",
-		"tags": [],
-		"extensions": {
-			"website": "https://daios.io/"
-		}
-	},
-  {
-    "chainId": 101,
-    "address": "4JEaBv49a4KdSrMduKZS3PcBCcPmPEmaY3uP7kXv6cj6",
-    "symbol": "$ASS",
-    "name": "Ass Coin",
-    "decimals": 9,
-    "logoUri": "https://static-api-cuazlhxxrq-uk.a.run.app/static/token.png",
-    "tags": [
-      "MEMES-TOKEN",
-      "NFTS",
-      "DEX"
-    ],
-    "extensions": {
-      "website": "https://solanadonkey.business",
-      "twitter": "https://twitter.com/solanadonkeBs"
-    }
-  },
-{
+    {
+      "chainId": 101,
+      "address": "FEYFyLCFLcBNfSuaf2eXNvyY5Jpii7zg9X48Br5vyenG",
+      "symbol": "SUSDT",
+      "name": "Stether",
+      "decimals": 2,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/FEYFyLCFLcBNfSuaf2eXNvyY5Jpii7zg9X48Br5vyenG/logo.png",
+      "tags": [
+        "stablecoin"
+      ],
+      "extensions": {
+        "website": "https://stether.io/"
+      }
+    },
+    {
+      "chainId": 102,
+      "address": "8ZY7EkwN7LxifYvvrQDbpjqxkrjHUFMwWgq8fupNNvub",
+      "symbol": "BIAD",
+      "name": "daib test token",
+      "decimals": 6,
+      "logoURI": "https://s3.us-west-2.amazonaws.com/secure.notion-static.com/02242929-14bc-4204-ac71-56d855a07078/512_daia.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAT73L2G45O3KS52Y5%2F20211104%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20211104T051518Z&X-Amz-Expires=86400&X-Amz-Signature=df1424dcb1be408faa45ef6af1f7769edf977da365822e00c34a2150167bfe58&X-Amz-SignedHeaders=host&response-content-disposition=filename%20%3D%22512_daia.png%22",
+      "tags": [],
+      "extensions": {
+        "website": "https://daios.io/"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "4JEaBv49a4KdSrMduKZS3PcBCcPmPEmaY3uP7kXv6cj6",
+      "symbol": "$ASS",
+      "name": "Ass Coin",
+      "decimals": 9,
+      "logoUri": "https://static-api-cuazlhxxrq-uk.a.run.app/static/token.png",
+      "tags": [
+        "MEMES-TOKEN",
+        "NFTS",
+        "DEX"
+      ],
+      "extensions": {
+        "website": "https://solanadonkey.business",
+        "twitter": "https://twitter.com/solanadonkeBs"
+      }
+    },
+    {
       "chainId": 101,
       "address": "NpgsBSfavf5hmUeGQAbMz5pHDtXhn9ZFNRQypTr8Tfv",
       "symbol": "NSPACE",
@@ -758,8 +791,8 @@
         "twitter": "https://twitter.com/mynftspace_art"
       }
     },
-	{
-	  "chainId": 101,
+    {
+      "chainId": 101,
       "address": "67Z7Pr4pX5iMczBox2bCgeU7Dy6SJRm2kZaMJoptstse",
       "symbol": "KOMO",
       "name": "Komondor",
@@ -779,8 +812,8 @@
         "github": "https://github.com/komondorok",
         "description": "KOMO is a community token, Dex, and Dapps on Solana."
       }
-	},
-	{
+    },
+    {
       "chainId": 101,
       "address": "p31qJ7LDLNRC57rU5GsXxFGBsnXheFXSsEn3avPoKDc",
       "symbol": "ARTC",
@@ -788,26 +821,31 @@
       "decimals": 8,
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/p31qJ7LDLNRC57rU5GsXxFGBsnXheFXSsEn3avPoKDc/logo.png",
       "tags": [
-         "nft",
-         "nft marketplace",
-         "artchive nft marketplace",
-         "artchive nft",
-         "governance token",
-         "governance coin"
-            ],
-         "extensions": {
-         "website": "https://artchivecoins.com/",
-         "instagram": "https://www.instagram.com/artchive.nft/"
+        "nft",
+        "nft marketplace",
+        "artchive nft marketplace",
+        "artchive nft",
+        "governance token",
+        "governance coin"
+      ],
+      "extensions": {
+        "website": "https://artchivecoins.com/",
+        "instagram": "https://www.instagram.com/artchive.nft/"
       }
     },
-    {  "chainId": 101,
+    {
+      "chainId": 101,
       "address": "BiDB55p4G3n1fGhwKFpxsokBMqgctL4qnZpDH1bVQxMD",
       "symbol": "DIO",
       "name": "Decimated",
       "decimals": 9,
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/BiDB55p4G3n1fGhwKFpxsokBMqgctL4qnZpDH1bVQxMD/logo.png",
       "tags": [
-        "decimated", "DIO", "videogame","utility-token","virtual-currency"
+        "decimated",
+        "DIO",
+        "videogame",
+        "utility-token",
+        "virtual-currency"
       ],
       "extensions": {
         "twitter": "https://twitter.com/decimated_game",
@@ -831,7 +869,8 @@
         "medium": "https://medium.com/@akelasolana",
         "twitter": "https://twitter.com/AkelaTOKEN"
       }
-    },    {
+    },
+    {
       "chainId": 101,
       "address": "3EkHyexJLGCvSxzn5umbtd9N69GoT4p5pfdLTFqCNP9Y",
       "symbol": "HIPPO",
@@ -935,21 +974,24 @@
       "decimals": 1,
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/6SKogZxCWY9jKsKPMT3ChJUhQxAEeB6NjVidXQK6TEdW/Logo.png",
       "tags": [
-      "community-token", "meme-token", "doge","dogecoin", "shiba inu", "Golden Doge"
+        "community-token",
+        "meme-token",
+        "doge",
+        "dogecoin",
+        "shiba inu",
+        "Golden Doge"
       ],
       "extensions": {
         "twitter": "https://twitter.com/GoldSolDoge",
         "website": "https://http://www.goldsoldoge.com/"
       },
-
-   
       "chainId": 101,
       "address": "B7RDhZ2iqE4FEwK5nfcZ9r2xhVL6rQJCo1dcjDXnF688",
       "symbol": "LAT",
       "name": "Latte",
       "decimals": 8,
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/B7RDhZ2iqE4FEwK5nfcZ9r2xhVL6rQJCo1dcjDXnF688/logo.png",
-      "tags":[],
+      "tags": [],
       "extensions": {
         "website": "https://www.lattetoken.com",
         "twitter": "https://twitter.com/lattenft"
@@ -973,13 +1015,13 @@
         "discord": "https://discord.gg/qR4BA9QXVR"
       }
     },
-  	 {
-    "chainId": 101,
-    "address": "7JYZmXjHenJxgLUtBxgYsFfoABmWQFA1fW3tHQKUBThV",
-    "symbol": "WEED",
-    "name": "Solana Weed",
-    "decimals": 6,
-     "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/7JYZmXjHenJxgLUtBxgYsFfoABmWQFA1fW3tHQKUBThV/logo.png",
+    {
+      "chainId": 101,
+      "address": "7JYZmXjHenJxgLUtBxgYsFfoABmWQFA1fW3tHQKUBThV",
+      "symbol": "WEED",
+      "name": "Solana Weed",
+      "decimals": 6,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/7JYZmXjHenJxgLUtBxgYsFfoABmWQFA1fW3tHQKUBThV/logo.png",
       "tags": [
         "social-token",
         "utility-token"
@@ -991,96 +1033,101 @@
         "discord": "https://discord.gg/3cshJ2gVz6"
       }
     },
-  {
-    "chainId": 101,
-    "address": "GaAzf7jwEKTouDXJExH9TKfvX3Ae7fLaGwNuEajq7KsE",
-    "symbol": "BARK",
-    "name": "Bark! o' Finance",
-    "decimals": 1,
-    "logoURI": "https://i.imgur.com/X90vi6d.png",
-    "tags": [
-      "meme-token",
-      "utility-token"
-    ],
-    "extensions": {
-      "twitter": "https://twitter.com/Bark_Solana"
-    }
-  },
-{
-          "chainId": 101,
-          "address": "5jFnsfx36DyGk8uVGrbXnVUMTsBkPXGpx6e69BiGFzko",
-          "symbol": "INU",
-          "name": "Solana INU",
-          "decimals": 9,
-          "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/5jFnsfx36DyGk8uVGrbXnVUMTsBkPXGpx6e69BiGFzko/logo.png",
-          "tags": ["Meme-token"],
-          "extensions": {
-            "discord": "https://discord.gg/solanainu",
-            "coingeckoId": "solana-inu",
-            "serumV3Usdc": "G3Bss3a2tif6eHNzWCh14g5k2H4rwBAmE42tbckUWG5T",
-            "twitter":"https://twitter.com/solanainu",
-            "website": "http://solanainu.org"
-          }
-        },
-{
-  "chainId": 101,
-  "address": "GJsBLZPMConURkFkewZskmJLFjnYVSENZtHjqV7GnohC",
-  "symbol": "EMON",
-  "name": "DORAEMON TOKEN FANS",
-  "decimals": 9,
-  "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/GJsBLZPMConURkFkewZskmJLFjnYVSENZtHjqV7GnohC/logo.png",
-  "tags": [
-    "MEMES-TOKEN",
-    "NFTs",
-    "DEX"
-  ],
-  "extensions": {
-    "website": "https://doraemon.org",
-    "twitter": "https://twitter.com/emontoken",
-    "telegram": "https://t.me/emontoken"
-  }
-},
-{
+    {
+      "chainId": 101,
+      "address": "GaAzf7jwEKTouDXJExH9TKfvX3Ae7fLaGwNuEajq7KsE",
+      "symbol": "BARK",
+      "name": "Bark! o' Finance",
+      "decimals": 1,
+      "logoURI": "https://i.imgur.com/X90vi6d.png",
+      "tags": [
+        "meme-token",
+        "utility-token"
+      ],
+      "extensions": {
+        "twitter": "https://twitter.com/Bark_Solana"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "5jFnsfx36DyGk8uVGrbXnVUMTsBkPXGpx6e69BiGFzko",
+      "symbol": "INU",
+      "name": "Solana INU",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/5jFnsfx36DyGk8uVGrbXnVUMTsBkPXGpx6e69BiGFzko/logo.png",
+      "tags": [
+        "Meme-token"
+      ],
+      "extensions": {
+        "discord": "https://discord.gg/solanainu",
+        "coingeckoId": "solana-inu",
+        "serumV3Usdc": "G3Bss3a2tif6eHNzWCh14g5k2H4rwBAmE42tbckUWG5T",
+        "twitter": "https://twitter.com/solanainu",
+        "website": "http://solanainu.org"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "GJsBLZPMConURkFkewZskmJLFjnYVSENZtHjqV7GnohC",
+      "symbol": "EMON",
+      "name": "DORAEMON TOKEN FANS",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/GJsBLZPMConURkFkewZskmJLFjnYVSENZtHjqV7GnohC/logo.png",
+      "tags": [
+        "MEMES-TOKEN",
+        "NFTs",
+        "DEX"
+      ],
+      "extensions": {
+        "website": "https://doraemon.org",
+        "twitter": "https://twitter.com/emontoken",
+        "telegram": "https://t.me/emontoken"
+      }
+    },
+    {
       "chainId": 101,
       "address": "7mNihWEjzWv9yCZc8capE4mS8v5Xvp5YH2yQhtZrQV5B",
       "symbol": "SBreakpoint",
       "name": "Solana Breakpoint",
       "decimals": 9,
       "logoURI": "https://raw.githubusercontent.com/tribeland/token-list/main/assets/mainnet/7mNihWEjzWv9yCZc8capE4mS8v5Xvp5YH2yQhtZrQV5B/logo.png",
-      "tags": ["meme-token"],
+      "tags": [
+        "meme-token"
+      ],
       "extensions": {
-       	"discord": "https://discord.gg/8jSUfzjjDG"
-        
+        "discord": "https://discord.gg/8jSUfzjjDG"
       }
     },
-
-
-{
-    "chainId": 101,
-    "address": "6Km8PRUQxPmNX6EhmAuu3sFEnCP6uT2Yt42zPFR6VNnD",
-    "symbol": "RUG",
-    "name": "RugCoin",
-    "decimals": 8,
-    "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/6Km8PRUQxPmNX6EhmAuu3sFEnCP6uT2Yt42zPFR6VNnD/logo.png",
-    "tags": [
-      "community-token", "meme-token", "rug"
-    ],
-    "extensions": {
-      "website": "https://rugcoin.rip"
-    }
-},
-{
-  "chainId": 101,
-  "address": "JTTez7NDqtU4ZqZJmLLXt6K9f75izfTApQqmvMCn4jU",
-  "symbol":"JTT",
-  "name": "Japan Travel Token",
-  "decimals": 0,
-  "logoURI": "http://www.japantravel.me/jtticon.png",
-  "tags": ["utility-token"],
-  "extensions": {
-    "website": " https://www.japantravel.me"
-  }
-},
+    {
+      "chainId": 101,
+      "address": "6Km8PRUQxPmNX6EhmAuu3sFEnCP6uT2Yt42zPFR6VNnD",
+      "symbol": "RUG",
+      "name": "RugCoin",
+      "decimals": 8,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/6Km8PRUQxPmNX6EhmAuu3sFEnCP6uT2Yt42zPFR6VNnD/logo.png",
+      "tags": [
+        "community-token",
+        "meme-token",
+        "rug"
+      ],
+      "extensions": {
+        "website": "https://rugcoin.rip"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "JTTez7NDqtU4ZqZJmLLXt6K9f75izfTApQqmvMCn4jU",
+      "symbol": "JTT",
+      "name": "Japan Travel Token",
+      "decimals": 0,
+      "logoURI": "http://www.japantravel.me/jtticon.png",
+      "tags": [
+        "utility-token"
+      ],
+      "extensions": {
+        "website": " https://www.japantravel.me"
+      }
+    },
     {
       "chainId": 101,
       "address": "7K1ad6gYMDbRssecDkGdGpaRueSezZpgD28uYsyaEA8f",
@@ -1097,7 +1144,7 @@
         "twitter": "https://twitter.com/Solnack_NFT"
       }
     },
-	{
+    {
       "chainId": 101,
       "address": "8hK6Vq53gwwYmvM2HuEeycGFn6ZDfynccHSuNJhWrTyd",
       "symbol": "1Coin",
@@ -1107,13 +1154,14 @@
       "tags": [
         "social-token",
         "utility-token",
-		"social-token"
-      ],     
-	 "extensions": {
-		  "website": "https://1coin.cx",
-	  "twitter": "https://twitter.com/1coincx",
-	  "github": "https://github.com/1coin1"
-    }},
+        "social-token"
+      ],
+      "extensions": {
+        "website": "https://1coin.cx",
+        "twitter": "https://twitter.com/1coincx",
+        "github": "https://github.com/1coin1"
+      }
+    },
     {
       "chainId": 101,
       "address": "3SaUThdYFoUX2FYUi9ZPf2TKTu3UYKhNHhXb2Y6najRg",
@@ -1129,50 +1177,64 @@
         "facebook": "https://www.facebook.com/Hello-Entertainment-103715111864185"
       }
     },
-{
-  "chainId": 101,
-  "address": "9ae76zqD3cgzR9gvf5Thc2NN3ACF7rqqnrLqxNzgcre6",
-  "symbol": "WIPE",
-  "name": "WipeMyAss",
-  "decimals": 9,
-  "logoURI": "https://cdn.jsdelivr.net/gh/rxrxrxrx/WipeMyAss/wipemyass.jpg",
-  "tags": [
-  "community-token", "meme-token", "doge","dogecoin", "shiba inu", "solcum", "monkey", "woof", "soldoge", "samo", "smb", "thugbirdz"
-  ],
-  "extensions": {
- "coingeckoId": "wipemyass",
-    "serumV3Usdc": "3kuUc5eTZyi7qajuFfDMMUUkqreEkUKtxQbVCjdriKVz",
-    "twitter": "https://twitter.com/WipeMyAssNFT",
-    "website": "https://wipemyass.io/"
-  }
-},
-{
-  "chainId": 101,
-  "address": "FTkj421DxbS1wajE74J34BJ5a1o9ccA97PkK6mYq9hNQ",
-  "symbol": "MINECRAFT",
-  "name": "Synex Coin",
-  "decimals": 9,
-  "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/FTkj421DxbS1wajE74J34BJ5a1o9ccA97PkK6mYq9hNQ/logo.png",
-  "tags": [
-	"utility-token","community-token"
-  ],
-  "extensions": {
-    "website": "https://synexcoin.dev",
-	"discord": "https://discord.gg/N3BE44234A",
-	"telegram": "https://t.me/synexcoin"
-  }
-},
-{
+    {
+      "chainId": 101,
+      "address": "9ae76zqD3cgzR9gvf5Thc2NN3ACF7rqqnrLqxNzgcre6",
+      "symbol": "WIPE",
+      "name": "WipeMyAss",
+      "decimals": 9,
+      "logoURI": "https://cdn.jsdelivr.net/gh/rxrxrxrx/WipeMyAss/wipemyass.jpg",
+      "tags": [
+        "community-token",
+        "meme-token",
+        "doge",
+        "dogecoin",
+        "shiba inu",
+        "solcum",
+        "monkey",
+        "woof",
+        "soldoge",
+        "samo",
+        "smb",
+        "thugbirdz"
+      ],
+      "extensions": {
+        "coingeckoId": "wipemyass",
+        "serumV3Usdc": "3kuUc5eTZyi7qajuFfDMMUUkqreEkUKtxQbVCjdriKVz",
+        "twitter": "https://twitter.com/WipeMyAssNFT",
+        "website": "https://wipemyass.io/"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "FTkj421DxbS1wajE74J34BJ5a1o9ccA97PkK6mYq9hNQ",
+      "symbol": "MINECRAFT",
+      "name": "Synex Coin",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/FTkj421DxbS1wajE74J34BJ5a1o9ccA97PkK6mYq9hNQ/logo.png",
+      "tags": [
+        "utility-token",
+        "community-token"
+      ],
+      "extensions": {
+        "website": "https://synexcoin.dev",
+        "discord": "https://discord.gg/N3BE44234A",
+        "telegram": "https://t.me/synexcoin"
+      }
+    },
+    {
       "chainId": 101,
       "address": "EkDf4Nt89x4Usnxkj4sGHX7sWxkmmpiBzA4qdDkgEN6b",
       "symbol": "SOB",
       "name": "SolaLambo",
       "decimals": 9,
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/EkDf4Nt89x4Usnxkj4sGHX7sWxkmmpiBzA4qdDkgEN6b/logo.png",
-      "tags": ["community-token"],
+      "tags": [
+        "community-token"
+      ],
       "extensions": {
         "website": "https://sob.finance/",
-       "discord": "https://discord.gg/sy2xymyc7J",
+        "discord": "https://discord.gg/sy2xymyc7J",
         "twitter": "https://twitter.com/SolaLambo"
       }
     },
@@ -1214,7 +1276,7 @@
         "telegram": "https://t.me/gta_fiverp/"
       }
     },
-	{
+    {
       "chainId": 101,
       "address": "GqWbZDQaeJsiscgtGpDrJsNCxxeuHqJCGKs4oWBY1aYQ",
       "symbol": "GTA",
@@ -1264,7 +1326,7 @@
         "twitter": "https://twitter.com/nickchua5"
       }
     },
-	{
+    {
       "chainId": 101,
       "address": "6Vg88xUHUPU9MfddHpu2cgx6CdodReiU8eGLPJgyhyVZ",
       "symbol": "WLB",
@@ -1318,9 +1380,9 @@
       "decimals": 8,
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/AATiVPgFBTJejUJrmkwnwH8UTr69CtfodGVCwMvrCa2U/logo.png",
       "tags": [
-        "meme-token"
-        ,"nft-token"
-        ,"game-token"
+        "meme-token",
+        "nft-token",
+        "game-token"
       ],
       "extensions": {
         "website": "https://solmanians.com",
@@ -1337,7 +1399,7 @@
       "tags": [],
       "extensions": {
         "website": "https://almond.so/",
-        "twitter":" https://twitter.com/almond_so",
+        "twitter": " https://twitter.com/almond_so",
         "serumV3Usdc": "DNxn3qM61GZddidjrzc95398SCWhm5BUyt8Y8SdKYr8W"
       }
     },
@@ -1363,15 +1425,16 @@
       "name": "Uncle Murphy Coin",
       "decimals": 9,
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/DGeHh4eoxGau3iH7PfdTJdRhZu4FWNgDFF1Czd3tNemT/logo.png",
-      "tags": ["meme-token"],
+      "tags": [
+        "meme-token"
+      ],
       "extensions": {
-        "website": "https://unclemurphycoin.org/"
-		,
-		"twitter": "https://twitter.com/Driver29973042",
-		"telegram channel": "https://t.me/joinchat/1x2i0txLEOY2Yjgy"
+        "website": "https://unclemurphycoin.org/",
+        "twitter": "https://twitter.com/Driver29973042",
+        "telegram channel": "https://t.me/joinchat/1x2i0txLEOY2Yjgy"
       }
-	},
-      {
+    },
+    {
       "chainId": 101,
       "address": "ALKiRVrfLgzeAV2mCT7cJHKg3ZoPvsCRSV7VCRWnE8zQ",
       "symbol": "NEKI",
@@ -1380,7 +1443,7 @@
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/ALKiRVrfLgzeAV2mCT7cJHKg3ZoPvsCRSV7VCRWnE8zQ/logo.png",
       "tags": [
         "utility-token",
-		"meme-token",
+        "meme-token",
         "neki"
       ],
       "extensions": {
@@ -1431,7 +1494,6 @@
         "website": "https://tokeninfo.yolasite.com/"
       }
     },
-
     {
       "chainId": 101,
       "address": "CC1gRBjsu8c7sf79wVd2Ub46X1UntPd81T7tmw7sTVYp",
@@ -1455,7 +1517,8 @@
       "extensions": {
         "website": "https://remnanthighway.org"
       }
-    },    {
+    },
+    {
       "chainId": 101,
       "address": "9Sbzj4DnRW8qFnfvJWwXxQMRkWKAwHLs9NgDuBFjkVgW",
       "symbol": "PITDT",
@@ -1476,8 +1539,8 @@
       "logoURI": "https://boryoku-dragonz-public.s3.us-east-2.amazonaws.com/BokuBrew.png",
       "tags": [],
       "extensions": {
-          "website": "https://boryokudragonz.io",
-          "twitter": "https://twitter.com/BoryokuDragonz"
+        "website": "https://boryokudragonz.io",
+        "twitter": "https://twitter.com/BoryokuDragonz"
       }
     },
     {
@@ -1489,13 +1552,12 @@
       "logoURI": "https://oogi.com/icon.png",
       "tags": [],
       "extensions": {
-          "website": "https://oogi.com/"
-          ,
-          "twitter": "https://twitter.com/oogicoin",
-          "telegram": "https://t.me/oogicoin",
-          "discord": "https://discord.gg/oogi",
-          "coingeckoId": "oogi",
-		      "serumV3Usdc": "ANUCohkG9gamUn6ofZEbnzGkjtyMexDhnjCwbLDmQ8Ub"
+        "website": "https://oogi.com/",
+        "twitter": "https://twitter.com/oogicoin",
+        "telegram": "https://t.me/oogicoin",
+        "discord": "https://discord.gg/oogi",
+        "coingeckoId": "oogi",
+        "serumV3Usdc": "ANUCohkG9gamUn6ofZEbnzGkjtyMexDhnjCwbLDmQ8Ub"
       }
     },
     {
@@ -1507,10 +1569,9 @@
       "logoURI": "https://user-images.githubusercontent.com/93886730/140664862-6dd80bff-be30-4c68-a978-fcb205011d61.png",
       "tags": [],
       "extensions": {
-          "website": "https://ssa.gg"
-          ,
-          "twitter": "https://twitter.com/SSA_NFT",
-          "discord": "https://discord.gg/SSANFT"
+        "website": "https://ssa.gg",
+        "twitter": "https://twitter.com/SSA_NFT",
+        "discord": "https://discord.gg/SSANFT"
       }
     },
     {
@@ -1522,8 +1583,7 @@
       "logoURI": "https://www.spookeletons.com/assets/spookeletons_token.png",
       "tags": [],
       "extensions": {
-        "website": "https://www.spookeletons.com"
-        ,
+        "website": "https://www.spookeletons.com",
         "serumV3Usdc": "8nTQLcukiGQEQ1zguvmtLx95VJmZm5WxRsdBneaTGVmN"
       }
     },
@@ -1536,8 +1596,7 @@
       "logoURI": "https://www.spookeletons.com/assets/spookeletons_tokenv2.png",
       "tags": [],
       "extensions": {
-        "website": "https://www.spookeletons.com"
-        ,
+        "website": "https://www.spookeletons.com",
         "serumV3Usdc": "6b51zj1C78Tn7R3nd9j4GvyShbMNxxufbU3mqPmbDRcz"
       }
     },
@@ -1550,8 +1609,7 @@
       "logoURI": "https://www.turtles.com/turtles.png",
       "tags": [],
       "extensions": {
-        "website": "https://www.turtles.com/"
-        ,
+        "website": "https://www.turtles.com/",
         "serumV3Usdc": "2dKHkfJGKNxmtwdLcsqXFGcb8Xppw5RP6YVWEWjSfAHm"
       }
     },
@@ -1571,7 +1629,7 @@
         "website": "https://mapmetrics.org/"
       }
     },
-	{
+    {
       "chainId": 101,
       "address": "EFqYVEitSUpUTj2d9LSqun4eZ4BzouFuTPqQzU4hNtsS",
       "symbol": "MMaps",
@@ -1714,24 +1772,24 @@
       }
     },
     {
-          "chainId": 101,
-          "address": "Aojru8bfwZK6sgrx6exNazxASFZUjPpRY59byMrs6izt",
-          "symbol": "OINK",
-          "name": "OINK",
-          "decimals": 10,
-          "logoURI": "https://raw.githubusercontent.com/dungnc/luckypigsNFT/main/SYMBOL.jpeg",
-          "tags": [
-            "meme",
-                "social-token",
-            "oink"
-          ],
-          "extensions": {
-            "twitter": "https://twitter.com/GiftedLabs",
-            "website": "http://luckypignfts.com"
-          }
-        },
+      "chainId": 101,
+      "address": "Aojru8bfwZK6sgrx6exNazxASFZUjPpRY59byMrs6izt",
+      "symbol": "OINK",
+      "name": "OINK",
+      "decimals": 10,
+      "logoURI": "https://raw.githubusercontent.com/dungnc/luckypigsNFT/main/SYMBOL.jpeg",
+      "tags": [
+        "meme",
+        "social-token",
+        "oink"
+      ],
+      "extensions": {
+        "twitter": "https://twitter.com/GiftedLabs",
+        "website": "http://luckypignfts.com"
+      }
+    },
     {
-	      "chainId": 101,
+      "chainId": 101,
       "address": "5sM9xxcBTM9rWza6nEgq2cShA87JjTBx1Cu82LjgmaEg",
       "symbol": "BMBO",
       "name": "Bamboo",
@@ -1739,10 +1797,11 @@
       "logoURI": "https://raw.githubusercontent.com/rishkumaria/bamboo/main/bamboo.png",
       "tags": [],
       "extensions": {
-          "coingeckoId": "bamboo-coin",
-          "website": " "
+        "coingeckoId": "bamboo-coin",
+        "website": " "
       }
-    }, {
+    },
+    {
       "chainId": 101,
       "address": "5F3beSzHFv1m3T2Sqp7dNQPYrZeetLZ8JYe6QPW6cqKA",
       "symbol": "ZEUS",
@@ -2396,7 +2455,7 @@
         "twitter": "https://twitter.com/EverestDotOrg",
         "coingeckoId": "everid"
       }
-     },
+    },
     {
       "chainId": 101,
       "address": "9Vovr1bqDbMQ8DyaizdC7n1YVvSia8r3PQ1RcPFqpQAs",
@@ -3705,7 +3764,7 @@
         "coingeckoId": "reserve-rights-token"
       }
     },
-	{
+    {
       "chainId": 101,
       "address": "ChvvzHyRqCHnLVwMNz8amvQwgVLD8AELV7RgcFAxEhAf",
       "symbol": "DRIFT",
@@ -6244,7 +6303,7 @@
         "coingeckoId": "zeroswap"
       }
     },
-	{
+    {
       "chainId": 101,
       "address": "E8yz29LYVsmpMvbpqEsNUzTFU3mjNLLu4NmwXBdgBAJm",
       "symbol": "ZERO",
@@ -6997,23 +7056,24 @@
         "coingeckoId": "matic-network"
       }
     },
-  {
-    "chainId": 101,
-    "address": "yPRTUpLDftNej7p6QofNYgRArRXsm6Mvkzohj4bh4WM",
-    "symbol": "yPRT",
-    "name": "yPRT (Parrot Yield Token)",
-    "decimals": 6,
-    "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/yPRTUpLDftNej7p6QofNYgRArRXsm6Mvkzohj4bh4WM/logo.svg",
-    "extensions": {
-      "website": "https://parrot.fi",
-      "twitter": "https://twitter.com/gopartyparrot",
-      "telegram": "https://t.me/gopartyparrot",
-      "medium": "https://gopartyparrot.medium.com/",
-      "discord": "https://discord.gg/gopartyparrot",
-      "comment": ""
-    },"tags":[
-    ]
-  },
+    {
+      "chainId": 101,
+      "address": "yPRTUpLDftNej7p6QofNYgRArRXsm6Mvkzohj4bh4WM",
+      "symbol": "yPRT",
+      "name": "yPRT (Parrot Yield Token)",
+      "decimals": 6,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/yPRTUpLDftNej7p6QofNYgRArRXsm6Mvkzohj4bh4WM/logo.svg",
+      "extensions": {
+        "website": "https://parrot.fi",
+        "twitter": "https://twitter.com/gopartyparrot",
+        "telegram": "https://t.me/gopartyparrot",
+        "medium": "https://gopartyparrot.medium.com/",
+        "discord": "https://discord.gg/gopartyparrot",
+        "comment": ""
+      },
+      "tags": [
+      ]
+    },
     {
       "chainId": 101,
       "address": "Au9E8ygQdTJQZXmNKPdtLEP8rGjC4qsGRhkJgjFNPAr8",
@@ -7303,7 +7363,7 @@
         "twitter": "https://twitter.com/kingdefi2"
       }
     },
-	{
+    {
       "chainId": 101,
       "address": "p9tNnBf4PDA7WSSFj5EVZddai6WoEiNk5B5FMyeQLtu",
       "symbol": "TMI",
@@ -7312,14 +7372,14 @@
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/p9tNnBf4PDA7WSSFj5EVZddai6WoEiNk5B5FMyeQLtu/logo.png",
       "tags": [
         "wrapped",
-		"wormhole"
+        "wormhole"
       ],
       "extensions": {
         "address": "0x71845240485c5339b3192a820f5fa152c093d93a",
         "bridgeContract": "https://bscscan.com/address/0xB6F6D86a8f9879A9c87f643768d9efc38c1Da6E7",
         "assetContract": "https://bscscan.com/address/0x71845240485c5339b3192a820f5fa152c093d93a",
         "website": "https://cointumi.com",
-		"telegram": "https://t.me/cointumi",
+        "telegram": "https://t.me/cointumi",
         "twitter": "https://twitter.com/tumicommunity"
       }
     },
@@ -8440,7 +8500,9 @@
       "decimals": 9,
       "logoURI": "https://cdn.jsdelivr.net/gh/FinancialBlock/SwyftToken/Swyft.png",
       "tags": [
-        "utility-token", "meme-token", "social-token"
+        "utility-token",
+        "meme-token",
+        "social-token"
       ],
       "extensions": {
         "website": "http://swyftcoin.com"
@@ -8454,7 +8516,9 @@
       "decimals": 9,
       "logoURI": "https://cdn.jsdelivr.net/gh/FinancialBlock/SwyftToken/FAC.png",
       "tags": [
-        "utility-token", "meme-token", "social-token"
+        "utility-token",
+        "meme-token",
+        "social-token"
       ],
       "extensions": {
         "website": "http://financialaidcoin.com"
@@ -10048,7 +10112,7 @@
         "stablecoin"
       ]
     },
-	{
+    {
       "chainId": 103,
       "address": "zbLcPeHWQ7yQXT7fEYHeNBKGM3wdGhNYL9jryVpys5J",
       "symbol": "VDC",
@@ -11542,7 +11606,7 @@
       "name": "Andy token",
       "decimals": 0,
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/AndyTyTHiXSHT3DhKSehsg3BEdAWMHbw9xVeeDS3WZYh/logo.png"
-    },    
+    },
     {
       "chainId": 101,
       "address": "7CVZWtuaA34gQZazbWwDhK8kFwPUubAiPaPnz6gAFjxF",
@@ -11551,7 +11615,7 @@
       "decimals": 8,
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/7CVZWtuaA34gQZazbWwDhK8kFwPUubAiPaPnz6gAFjxF/logo.png"
     },
-	{
+    {
       "chainId": 101,
       "address": "VernWPaodzUcAXnZQAcCguQPbWJvUub1zuURzLvF128",
       "symbol": "VERNER",
@@ -11597,7 +11661,7 @@
         "discord": "http://discord.gg/mememarketplace"
       }
     },
-{
+    {
       "chainId": 101,
       "address": "pL5mVp1DByEFufunmymuBNFcSsyJftXguDMci7Jg1Du",
       "symbol": "MEW",
@@ -11610,7 +11674,6 @@
         "MEW"
       ]
     },
-
     {
       "chainId": 101,
       "address": "3iXydLpqi38CeGDuLFF1WRbPrrkNbUsgVf98cNSg6NaA",
@@ -11933,7 +11996,7 @@
       "tags": [],
       "extensions": {
         "website": "https://sollama.finance",
-		"serumV3Usdc": "6KKRzEedDY1dybdrfFzjDzTxCVuxdHgaiQFYUfoupigK",
+        "serumV3Usdc": "6KKRzEedDY1dybdrfFzjDzTxCVuxdHgaiQFYUfoupigK",
         "twitter": "https://twitter.com/SollamaFinance"
       }
     },
@@ -12082,20 +12145,20 @@
         "website": "https://grapes.network"
       }
     },
-	{
-	"chainId": 101,
-	"address": "6qAJ9W5XCb2JyrTRV8bcoXa6HmHNz9YikLMWK71dH1sY",
-	"symbol": "SOLEM",
-	"name": "SolemPad",
-	"decimals": 6,
-	"logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/6qAJ9W5XCb2JyrTRV8bcoXa6HmHNz9YikLMWK71dH1sY/logo.png",
-	"tags": [],
-	"extensions": {
-		"website": "https://www.solempad.net/",
-		"twitter": "https://www.twitter.com/solempad",
-		"telegram": "https://t.me/solempad"
-		}
-	},
+    {
+      "chainId": 101,
+      "address": "6qAJ9W5XCb2JyrTRV8bcoXa6HmHNz9YikLMWK71dH1sY",
+      "symbol": "SOLEM",
+      "name": "SolemPad",
+      "decimals": 6,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/6qAJ9W5XCb2JyrTRV8bcoXa6HmHNz9YikLMWK71dH1sY/logo.png",
+      "tags": [],
+      "extensions": {
+        "website": "https://www.solempad.net/",
+        "twitter": "https://www.twitter.com/solempad",
+        "telegram": "https://t.me/solempad"
+      }
+    },
     {
       "chainId": 101,
       "address": "7xzovRepzLvXbbpVZLYKzEBhCNgStEv1xpDqf1rMFFKX",
@@ -12167,19 +12230,19 @@
       }
     },
     {
-        "chainId": 101,
-        "address": "1C2EYVrwmoXAGbiKirFFBeDFDYUBHPhDeg9trhibTND",
-        "symbol": "NRA",
-        "name": "NORA",
-        "decimals": 9,
-        "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/1C2EYVrwmoXAGbiKirFFBeDFDYUBHPhDeg9trhibTND/logo.png",
-        "tags": [
-            "meme-token"
-        ],
-        "extensions": {
-            "twitter": "https://twitter.com/SolNoraToken"
-          }
-      },
+      "chainId": 101,
+      "address": "1C2EYVrwmoXAGbiKirFFBeDFDYUBHPhDeg9trhibTND",
+      "symbol": "NRA",
+      "name": "NORA",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/1C2EYVrwmoXAGbiKirFFBeDFDYUBHPhDeg9trhibTND/logo.png",
+      "tags": [
+        "meme-token"
+      ],
+      "extensions": {
+        "twitter": "https://twitter.com/SolNoraToken"
+      }
+    },
     {
       "chainId": 101,
       "address": "BrwgXmUtNd32dTKdP5teie68EmBnjGq8Wp3MukHehUBY",
@@ -12690,7 +12753,7 @@
         "twitter": "https://twitter.com/metaplex"
       }
     },
-  {
+    {
       "chainId": 101,
       "address": "BiJyWQr1Gpke3ouevgGCjtd9sSwSiUxdpnpGvJaoGQNL",
       "symbol": "SNG",
@@ -16345,7 +16408,7 @@
         "twitter": "https://twitter.com/mimswarm",
         "discord": "https://discord.gg/8mHbKWczpB",
         "telegram": "https://t.me/mimswarm",
-	"coingeckoId": "mim",
+        "coingeckoId": "mim",
         "github": "https://github.com/kyonym/MIM"
       }
     },
@@ -16613,9 +16676,9 @@
       "decimals": 6,
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/PRT88RkA4Kg5z7pKnezeNH4mafTvtQdfFgpQTGRjz44/logo.svg",
       "tags": [
-        "utility-token"
-        ,"POFA token"
-        ,"Meme-Token"
+        "utility-token",
+        "POFA token",
+        "Meme-Token"
       ],
       "extensions": {
         "website": "https://parrot.fi",
@@ -17179,22 +17242,22 @@
         "website": "https://www.abion.org/"
       }
     },
-	{
-  "chainId": 101,
-  "address": "EN1VhM7BmuqAuUDGDDnzXZdefaFpvNHFCAwjXzp6gRhJ",
-  "symbol": "BBS",
-  "name": "BONER",
-  "decimals": 6,
-  "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/EN1VhM7BmuqAuUDGDDnzXZdefaFpvNHFCAwjXzp6gRhJ/logo.png",
-  "tags": [
-    "utility-token",
-    "nft-token"
-  ],
-  "extensions": {
-    "website": "https://www.barebonesnft.com/",
-    "twitter": "https://twitter.com/BareBonesNFT"
-  }
-},
+    {
+      "chainId": 101,
+      "address": "EN1VhM7BmuqAuUDGDDnzXZdefaFpvNHFCAwjXzp6gRhJ",
+      "symbol": "BBS",
+      "name": "BONER",
+      "decimals": 6,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/EN1VhM7BmuqAuUDGDDnzXZdefaFpvNHFCAwjXzp6gRhJ/logo.png",
+      "tags": [
+        "utility-token",
+        "nft-token"
+      ],
+      "extensions": {
+        "website": "https://www.barebonesnft.com/",
+        "twitter": "https://twitter.com/BareBonesNFT"
+      }
+    },
     {
       "chainId": 101,
       "address": "CnGUfvi9FxiRPuaBXpYmaXEwBjj5X6kwNJB2Cba5TiQp",
@@ -19592,36 +19655,36 @@
         "coingeckoId": "usd-coin"
       }
     },
-{
-	"chainId": 101,
-	"address": "FLhkrAUE3kjwQwZPvAqDTAXULTgBUgjcAVtyzvwkcNrJ",
-	"symbol": "MBB",
-	"name": "Fraktionalized MBB #2793",
-	"decimals": 3,
-	"logoURI": "https://www.arweave.net/0RPQq5Z_808sLjsjZ67__kFbQYdfQNaztLpBuDPKaEA?ext=png",
-	"tags": [
-		"fractionalized-nft"
-	],
-	"extensions": {
-		"vault": "https://fraktion.art/vault/4q9s7Y3sAgbNi7AVwRSHJEnEWxugn8Fntk928rRsi6d9",
-		"vaultPubkey": "4q9s7Y3sAgbNi7AVwRSHJEnEWxugn8Fntk928rRsi6d9"
-	}
-},
-{
-	"chainId": 101,
-	"address": "Hk7P7ufaHe92Dx2Cmz6rSHT8RFj362kLYwMxJ9X5d7eF",
-	"symbol": "MBB",
-	"name": "Fraktionalized MBB #1007",
-	"decimals": 3,
-	"logoURI": "https://www.arweave.net/piH41aGwPKOVs_idwQGU-wh278ZPNmJPpjchwt_gAEc?ext=png",
-	"tags": [
-		"fractionalized-nft"
-	],
-	"extensions": {
-		"vault": "https://fraktion.art/vault/Ei5wPJtrKfLM9WD3Lj4Gmh31K2jsph4DtRAVH3oEJ2hi",
-		"vaultPubkey": "Ei5wPJtrKfLM9WD3Lj4Gmh31K2jsph4DtRAVH3oEJ2hi"
-	}
-},
+    {
+      "chainId": 101,
+      "address": "FLhkrAUE3kjwQwZPvAqDTAXULTgBUgjcAVtyzvwkcNrJ",
+      "symbol": "MBB",
+      "name": "Fraktionalized MBB #2793",
+      "decimals": 3,
+      "logoURI": "https://www.arweave.net/0RPQq5Z_808sLjsjZ67__kFbQYdfQNaztLpBuDPKaEA?ext=png",
+      "tags": [
+        "fractionalized-nft"
+      ],
+      "extensions": {
+        "vault": "https://fraktion.art/vault/4q9s7Y3sAgbNi7AVwRSHJEnEWxugn8Fntk928rRsi6d9",
+        "vaultPubkey": "4q9s7Y3sAgbNi7AVwRSHJEnEWxugn8Fntk928rRsi6d9"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "Hk7P7ufaHe92Dx2Cmz6rSHT8RFj362kLYwMxJ9X5d7eF",
+      "symbol": "MBB",
+      "name": "Fraktionalized MBB #1007",
+      "decimals": 3,
+      "logoURI": "https://www.arweave.net/piH41aGwPKOVs_idwQGU-wh278ZPNmJPpjchwt_gAEc?ext=png",
+      "tags": [
+        "fractionalized-nft"
+      ],
+      "extensions": {
+        "vault": "https://fraktion.art/vault/Ei5wPJtrKfLM9WD3Lj4Gmh31K2jsph4DtRAVH3oEJ2hi",
+        "vaultPubkey": "Ei5wPJtrKfLM9WD3Lj4Gmh31K2jsph4DtRAVH3oEJ2hi"
+      }
+    },
     {
       "chainId": 101,
       "address": "Dn4noZ5jgGfkntzcQSUZ8czkreiZ1ForXYoV2H8Dm7S1",
@@ -19678,14 +19741,12 @@
       "symbol": "HIMA",
       "name": "Himalayan Cat Coin",
       "decimals": 9,
-      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/72hgmvS5zFxaFJfMizq6Gp4gjBqXjTPyX9GDP38krorQ/logo.png"
-      ,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/72hgmvS5zFxaFJfMizq6Gp4gjBqXjTPyX9GDP38krorQ/logo.png",
       "extensions": {
         "website": "https://www.himalayancatcoin.com/",
-	"twitter": "https://twitter.com/himacoin"
-	,
-	"coingeckoId": "himalayan-cat-coin",
-	"serumV3Usdc": "HCE4wQXApNyFBTK7gYa98QCYbshCz7EkH8axNz3ahvKc"
+        "twitter": "https://twitter.com/himacoin",
+        "coingeckoId": "himalayan-cat-coin",
+        "serumV3Usdc": "HCE4wQXApNyFBTK7gYa98QCYbshCz7EkH8axNz3ahvKc"
       }
     },
     {
@@ -19763,84 +19824,84 @@
         "twitter": "https://twitter.com/FraktArt"
       }
     },
-{
-	"chainId": 101,
-	"address": "F5rdP7VxCDYy8xaAEksgLqUerCVty4BTe1CmoiCbmu7L",
-	"symbol": "TPW",
-	"name": "Fraktionalized Frakt-2795",
-	"decimals": 3,
-	"logoURI": "https://www.arweave.net/1LMJ9lC00xVIbUv_XK4FuIQGwm87ua30iRskQslP9Go",
-	"tags": [
-		"fractionalized-nft"
-	],
-	"extensions": {
-		"vault": "https://fraktion.art/vault/5oDXsghEWBitmjGuy8w3MPnkGjZkNc5pjFv3wf9pg1QT",
-		"vaultPubkey": "5oDXsghEWBitmjGuy8w3MPnkGjZkNc5pjFv3wf9pg1QT"
-	}
-},
-{
-	"chainId": 101,
-	"address": "Gc2yWrkqBti7zeWVFD5JWHhj3ouWkAhw3YRg1btYJ5Vw",
-	"symbol": "MMM",
-	"name": "Fraktionalized Moment-492",
-	"decimals": 3,
-	"logoURI": "https://www.arweave.net/YIxO-jtbg51k2auVaIg7L5RN4Ap0S1Vc-Jm_GrUcAgk?ext=jpeg",
-	"tags": [
-		"fractionalized-nft"
-	],
-	"extensions": {
-		"vault": "https://fraktion.art/vault/7D66e5MgEGN2BzYzogwtFNq6QNPqiFvKwD7Zx3fUytiY",
-		"vaultPubkey": "7D66e5MgEGN2BzYzogwtFNq6QNPqiFvKwD7Zx3fUytiY"
-	}
-},
-{
-	"chainId": 101,
-	"address": "2xQwcN3pQn7VvM4GnWMP8sBA2oPdDPtxnMNcLErZwTwh",
-	"symbol": "SSF",
-	"name": "Fraktionalized Silver Starfish",
-	"decimals": 3,
-	"logoURI": "https://www.arweave.net/ZOt3SVdXPHbVJVr8H13wVo_G5gHBYxDipo6jaTA549w?ext=png",
-	"tags": [
-		"fractionalized-nft"
-	],
-	"extensions": {
-		"vault": "https://fraktion.art/vault/6aVbY5fLCg5SqfLzZjp3Jo5BdTWBzS1ZuWfEiSuMTTFH",
-		"vaultPubkey": "6aVbY5fLCg5SqfLzZjp3Jo5BdTWBzS1ZuWfEiSuMTTFH"
-	}
-},
-{
-	"chainId": 101,
-	"address": "9jWgVR3Q3QjfmaXNiZ6jht2K43W7sqkn6tZFeoK9B48t",
-	"symbol": "JRDN",
-	"name": "Fraktionalized Triumphant",
-	"decimals": 3,
-	"logoURI": "https://www.arweave.net/B1rrktxxGta7w34MkEuFoJQxDzKLPXlYtBcR_1TkQPQ?ext=png",
-	"tags": [
-		"fractionalized-nft"
-	],
-	"extensions": {
-		"vault": "https://fraktion.art/vault/7uXCgfBQzL43hehzFhh8tBFTEggrcZJDfQRoRpgXNAeo",
-		"vaultPubkey": "7uXCgfBQzL43hehzFhh8tBFTEggrcZJDfQRoRpgXNAeo"
-	}
-},
-{
-	"chainId": 101,
-	"address": "DVPWKGLFHK73PwgKgTtW28iCZGewQdva2N5HeBLDorVJ",
-	"symbol": "GOATS",
-	"name": "GOATS",
-	"decimals": 9,
-	"logoURI": "https://www.solgoats.io/logo_full.png",
-	"tags": [
-		"meme-token",
-		"community-token"
-	],
-	"extensions": {
-		"website": "https://www.solgoats.io",
-		"twitter": "https://twitter.com/TheGOATSociety_",
-		"discord": "https://discord.gg/eUwEbWw6ww",
-		"serumV3Usdc": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
-	}
-},
+    {
+      "chainId": 101,
+      "address": "F5rdP7VxCDYy8xaAEksgLqUerCVty4BTe1CmoiCbmu7L",
+      "symbol": "TPW",
+      "name": "Fraktionalized Frakt-2795",
+      "decimals": 3,
+      "logoURI": "https://www.arweave.net/1LMJ9lC00xVIbUv_XK4FuIQGwm87ua30iRskQslP9Go",
+      "tags": [
+        "fractionalized-nft"
+      ],
+      "extensions": {
+        "vault": "https://fraktion.art/vault/5oDXsghEWBitmjGuy8w3MPnkGjZkNc5pjFv3wf9pg1QT",
+        "vaultPubkey": "5oDXsghEWBitmjGuy8w3MPnkGjZkNc5pjFv3wf9pg1QT"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "Gc2yWrkqBti7zeWVFD5JWHhj3ouWkAhw3YRg1btYJ5Vw",
+      "symbol": "MMM",
+      "name": "Fraktionalized Moment-492",
+      "decimals": 3,
+      "logoURI": "https://www.arweave.net/YIxO-jtbg51k2auVaIg7L5RN4Ap0S1Vc-Jm_GrUcAgk?ext=jpeg",
+      "tags": [
+        "fractionalized-nft"
+      ],
+      "extensions": {
+        "vault": "https://fraktion.art/vault/7D66e5MgEGN2BzYzogwtFNq6QNPqiFvKwD7Zx3fUytiY",
+        "vaultPubkey": "7D66e5MgEGN2BzYzogwtFNq6QNPqiFvKwD7Zx3fUytiY"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "2xQwcN3pQn7VvM4GnWMP8sBA2oPdDPtxnMNcLErZwTwh",
+      "symbol": "SSF",
+      "name": "Fraktionalized Silver Starfish",
+      "decimals": 3,
+      "logoURI": "https://www.arweave.net/ZOt3SVdXPHbVJVr8H13wVo_G5gHBYxDipo6jaTA549w?ext=png",
+      "tags": [
+        "fractionalized-nft"
+      ],
+      "extensions": {
+        "vault": "https://fraktion.art/vault/6aVbY5fLCg5SqfLzZjp3Jo5BdTWBzS1ZuWfEiSuMTTFH",
+        "vaultPubkey": "6aVbY5fLCg5SqfLzZjp3Jo5BdTWBzS1ZuWfEiSuMTTFH"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "9jWgVR3Q3QjfmaXNiZ6jht2K43W7sqkn6tZFeoK9B48t",
+      "symbol": "JRDN",
+      "name": "Fraktionalized Triumphant",
+      "decimals": 3,
+      "logoURI": "https://www.arweave.net/B1rrktxxGta7w34MkEuFoJQxDzKLPXlYtBcR_1TkQPQ?ext=png",
+      "tags": [
+        "fractionalized-nft"
+      ],
+      "extensions": {
+        "vault": "https://fraktion.art/vault/7uXCgfBQzL43hehzFhh8tBFTEggrcZJDfQRoRpgXNAeo",
+        "vaultPubkey": "7uXCgfBQzL43hehzFhh8tBFTEggrcZJDfQRoRpgXNAeo"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "DVPWKGLFHK73PwgKgTtW28iCZGewQdva2N5HeBLDorVJ",
+      "symbol": "GOATS",
+      "name": "GOATS",
+      "decimals": 9,
+      "logoURI": "https://www.solgoats.io/logo_full.png",
+      "tags": [
+        "meme-token",
+        "community-token"
+      ],
+      "extensions": {
+        "website": "https://www.solgoats.io",
+        "twitter": "https://twitter.com/TheGOATSociety_",
+        "discord": "https://discord.gg/eUwEbWw6ww",
+        "serumV3Usdc": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+      }
+    },
     {
       "chainId": 101,
       "address": "DYegPLaJuNvicevUUoC77ek6Xfwi4s4Pabr8scLGopSU",
@@ -19857,7 +19918,7 @@
         "website": "https://synergyland.world/"
       }
     },
-{
+    {
       "chainId": 101,
       "address": "3TMdBbnXKASdx9rBcZ5HQsyqCky7Gt2ea44gYB6Ro15A",
       "symbol": "SFOX",
@@ -20098,7 +20159,7 @@
         "serumV3Usdc": "EhABxYSBodQF7vz6D633cxCG7BSK1S6NrNNPVMSpKLct"
       }
     },
-	{
+    {
       "chainId": 101,
       "address": "6X4jtyjKQmNx9zEPjzt1A3hcKEX7fi6BX3ruQ79sLa75",
       "symbol": "ATG",
@@ -20267,19 +20328,19 @@
       ],
       "extensions": {}
     },
-      {
-  "chainId": 101,
-  "address": "3vQ58RPSjGqpKRXpDnrMpKRry4ZeQcBPmhzkVZSZ2kGs",
-  "symbol": "BHCC",
-  "name": "The Beverly Hills Car Club",
-  "decimals": 0,
-  "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/3vQ58RPSjGqpKRXpDnrMpKRry4ZeQcBPmhzkVZSZ2kGs/logo.png",
-  "tags": [],
-  "extensions": {
-    "website": "https://beverlyhillscarclub.io/",
-    "twitter": "https://twitter.com/bevhillscarclub"
-    }
-  },
+    {
+      "chainId": 101,
+      "address": "3vQ58RPSjGqpKRXpDnrMpKRry4ZeQcBPmhzkVZSZ2kGs",
+      "symbol": "BHCC",
+      "name": "The Beverly Hills Car Club",
+      "decimals": 0,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/3vQ58RPSjGqpKRXpDnrMpKRry4ZeQcBPmhzkVZSZ2kGs/logo.png",
+      "tags": [],
+      "extensions": {
+        "website": "https://beverlyhillscarclub.io/",
+        "twitter": "https://twitter.com/bevhillscarclub"
+      }
+    },
     {
       "chainId": 101,
       "address": "HPcpwJ5arSHjJDYGmJQYCuHKDfWLqjdmRrb6bhadRkxG",
@@ -20330,7 +20391,7 @@
         "twitter": "https://twitter.com/quidtoken"
       }
     },
-	{
+    {
       "chainId": 101,
       "address": "yvbrxE6zjrA8SxxSpL7oojDBB5QDmF5CVqJWea8JcQE",
       "symbol": "CODI",
@@ -20445,7 +20506,7 @@
         "Auction"
       ]
     },
-	{
+    {
       "chainId": 103,
       "address": "J9JkoZFdi31nJAcSniPMemfneJ7AL2iMYZkrEC9yvTDK",
       "symbol": "Book",
@@ -20875,7 +20936,7 @@
       "symbol": "CPR",
       "name": "Crypto Republic",
       "decimals": 5,
-	  "extensions": {
+      "extensions": {
         "website": "https://cryptorepublictoken.com/"
       },
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/5sBG2b32gk3jsd5azCK4Xs8jH9V6szz3vm9fi7v2cRrC/logo.png"
@@ -20997,16 +21058,16 @@
         "discord": "https://discord.gg/dVjvdgwvf4"
       }
     },
-	{
-		"chainId": 101,
-		"address": "DTn6z1ikPcKa62KHeP7wFgSrq2NvCC1zEUqyJvTdso17",
-		"symbol": "PHX",
-		"name": "Phinx",
-		"decimals": 6,
-		"logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/DTn6z1ikPcKa62KHeP7wFgSrq2NvCC1zEUqyJvTdso17/logo.png",
-		"tags": [],
-		"extensions": {}
-	},
+    {
+      "chainId": 101,
+      "address": "DTn6z1ikPcKa62KHeP7wFgSrq2NvCC1zEUqyJvTdso17",
+      "symbol": "PHX",
+      "name": "Phinx",
+      "decimals": 6,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/DTn6z1ikPcKa62KHeP7wFgSrq2NvCC1zEUqyJvTdso17/logo.png",
+      "tags": [],
+      "extensions": {}
+    },
     {
       "chainId": 101,
       "address": "21cpwEpusR6gR65T3ymiJx16VS7M8VCqRTY4XjQbLBwh",
@@ -21122,7 +21183,7 @@
         "discord": "https://discord.gg/zMvCkck2k2"
       }
     },
-     {
+    {
       "chainId": 101,
       "address": "9yqPadcWQQ4BnuEbEZci1M5pTQYV8LX1HvckYwXoACdL",
       "symbol": "MYCTY",
@@ -21130,8 +21191,8 @@
       "decimals": 6,
       "logoURI": "http://mycryptocity.net/wp-content/uploads/2021/10/cropped-HDLog2.png",
       "tags": [
-      "utility-token",
-      "game",
+        "utility-token",
+        "game",
         "play2earn"
       ],
       "extensions": {
@@ -21621,125 +21682,125 @@
         "telegram": "https://t.me/cointumi"
       }
     },
-	  {
-	    "chainId": 101,
-	    "address": "3k6zY8YUQsVPiXHh8Ncfw9BgMBcQzKq2B5TJfmSDbMZr",
-	    "symbol": "PEP",
-	    "name": "SolPepper",
-	    "decimals": 4,
-	    "logoURI": "https://lizardtoken.xyz/gallery/pepper-ts1635027628.jpg",
-	    "tags": [],
-	    "extensions": {
-	      "website": "https://solpepper.xyz"
-	    }
+    {
+      "chainId": 101,
+      "address": "3k6zY8YUQsVPiXHh8Ncfw9BgMBcQzKq2B5TJfmSDbMZr",
+      "symbol": "PEP",
+      "name": "SolPepper",
+      "decimals": 4,
+      "logoURI": "https://lizardtoken.xyz/gallery/pepper-ts1635027628.jpg",
+      "tags": [],
+      "extensions": {
+        "website": "https://solpepper.xyz"
+      }
     },
-	  {
-	    "chainId": 101,
-	    "address": "5hownqSTYjtGJi1u117siKxLXBEAMhkRZaVBM21rwh86",
-	    "symbol": "DOG",
-	    "name": "DogSol",
-	    "decimals": 4,
-	    "logoURI": "https://lizardtoken.xyz/gallery/dog-ts1635027588.png",
-	    "tags": [],
-	    "extensions": {
-	      "website": "https://dogsol.xyz"
-	    }
+    {
+      "chainId": 101,
+      "address": "5hownqSTYjtGJi1u117siKxLXBEAMhkRZaVBM21rwh86",
+      "symbol": "DOG",
+      "name": "DogSol",
+      "decimals": 4,
+      "logoURI": "https://lizardtoken.xyz/gallery/dog-ts1635027588.png",
+      "tags": [],
+      "extensions": {
+        "website": "https://dogsol.xyz"
+      }
     },
-	  {
-	    "chainId": 101,
-	    "address": "CmjegnBmHaEN2wbHTemVr1xwfgN61JZBgbtLkAa3WHM8",
-	    "symbol": "SILVER",
-	    "name": "SilverSol",
-	    "decimals": 4,
-	    "logoURI": "https://lizardtoken.xyz/gallery/silver-ts1635027635.png",
-	    "tags": [],
-	    "extensions": {
-	      "website": "https://silversol.xyz"
-	    }
+    {
+      "chainId": 101,
+      "address": "CmjegnBmHaEN2wbHTemVr1xwfgN61JZBgbtLkAa3WHM8",
+      "symbol": "SILVER",
+      "name": "SilverSol",
+      "decimals": 4,
+      "logoURI": "https://lizardtoken.xyz/gallery/silver-ts1635027635.png",
+      "tags": [],
+      "extensions": {
+        "website": "https://silversol.xyz"
+      }
     },
-	  {
-	    "chainId": 101,
-	    "address": "DjDBpTJdatCrfR4XRWgKiQ8WY6K6RNuMsyTKAQ8rK9Rp",
-	    "symbol": "BRD",
-	    "name": "SolBird",
-	    "decimals": 4,
-	    "logoURI": "https://lizardtoken.xyz/gallery/bird-ts1635027934.png",
-	    "tags": [],
-	    "extensions": {
-	      "website": "https://solbird.xyz"
-	    }
+    {
+      "chainId": 101,
+      "address": "DjDBpTJdatCrfR4XRWgKiQ8WY6K6RNuMsyTKAQ8rK9Rp",
+      "symbol": "BRD",
+      "name": "SolBird",
+      "decimals": 4,
+      "logoURI": "https://lizardtoken.xyz/gallery/bird-ts1635027934.png",
+      "tags": [],
+      "extensions": {
+        "website": "https://solbird.xyz"
+      }
     },
-	  {
-	    "chainId": 101,
-	    "address": "BfbhLmrhtELjfFzrtcxpB1GoTpmiVK8qcpSYf7AM914h",
-	    "symbol": "BIRD",
-	    "name": "SolBird2",
-	    "decimals": 4,
-	    "logoURI": "https://lizardtoken.xyz/gallery/bird2-ts1635029482.png",
-	    "tags": [],
-	    "extensions": {
-	      "website": "https://solbird2.xyz"
-	    }
+    {
+      "chainId": 101,
+      "address": "BfbhLmrhtELjfFzrtcxpB1GoTpmiVK8qcpSYf7AM914h",
+      "symbol": "BIRD",
+      "name": "SolBird2",
+      "decimals": 4,
+      "logoURI": "https://lizardtoken.xyz/gallery/bird2-ts1635029482.png",
+      "tags": [],
+      "extensions": {
+        "website": "https://solbird2.xyz"
+      }
     },
-	  {
-	    "chainId": 101,
-	    "address": "7pFo8CrTJuQFxRaTJT7k2TEQFGMijcGjQpcc4hFcmco1",
-	    "symbol": "CAT",
-	    "name": "SolCat",
-	    "decimals": 4,
-	    "logoURI": "https://lizardtoken.xyz/gallery/cat-ts1635027580.jpg",
-	    "tags": [],
-	    "extensions": {
-	      "website": "https://solcat.xyz"
-	    }
+    {
+      "chainId": 101,
+      "address": "7pFo8CrTJuQFxRaTJT7k2TEQFGMijcGjQpcc4hFcmco1",
+      "symbol": "CAT",
+      "name": "SolCat",
+      "decimals": 4,
+      "logoURI": "https://lizardtoken.xyz/gallery/cat-ts1635027580.jpg",
+      "tags": [],
+      "extensions": {
+        "website": "https://solcat.xyz"
+      }
     },
-	  {
-	    "chainId": 101,
-	    "address": "3Wup5AtKjDki1yX75WZuzGbqrNJTmLPvVPMwWEhBNKES",
-	    "symbol": "BLISS",
-	    "name": "SolFlower",
-	    "decimals": 4,
-	    "logoURI": "https://lizardtoken.xyz/gallery/flower-ts1635027605.jpg",
-	    "tags": [],
-	    "extensions": {
-	      "website": "https://solflower.xyz"
-	    }
+    {
+      "chainId": 101,
+      "address": "3Wup5AtKjDki1yX75WZuzGbqrNJTmLPvVPMwWEhBNKES",
+      "symbol": "BLISS",
+      "name": "SolFlower",
+      "decimals": 4,
+      "logoURI": "https://lizardtoken.xyz/gallery/flower-ts1635027605.jpg",
+      "tags": [],
+      "extensions": {
+        "website": "https://solflower.xyz"
+      }
     },
-	  {
-	    "chainId": 101,
-	    "address": "A8fqp3MkJnDH9L5UzUdckfv2HPAzpqPbpFMRmnYGkZsj",
-	    "symbol": "DRGN",
-	    "name": "DragonSol",
-	    "decimals": 4,
-	    "logoURI": "https://lizardtoken.xyz/gallery/dragon-ts1635027595.jpg",
-	    "tags": [],
-	    "extensions": {
-	      "website": "https://dragonsol.xyz"
-	    }
+    {
+      "chainId": 101,
+      "address": "A8fqp3MkJnDH9L5UzUdckfv2HPAzpqPbpFMRmnYGkZsj",
+      "symbol": "DRGN",
+      "name": "DragonSol",
+      "decimals": 4,
+      "logoURI": "https://lizardtoken.xyz/gallery/dragon-ts1635027595.jpg",
+      "tags": [],
+      "extensions": {
+        "website": "https://dragonsol.xyz"
+      }
     },
-	  {
-	    "chainId": 101,
-	    "address": "7TXxsfjYt8gR1XZh9vZZNRxhA4t2VxtYbsy9JWHRjFhJ",
-	    "symbol": "MOON",
-	    "name": "MoonSol",
-	    "decimals": 4,
-	    "logoURI": "https://lizardtoken.xyz/gallery/moon-ts1635027621.jpg",
-	    "tags": [],
-	    "extensions": {
-	      "website": "https://moonsol.xyz"
-	    }
+    {
+      "chainId": 101,
+      "address": "7TXxsfjYt8gR1XZh9vZZNRxhA4t2VxtYbsy9JWHRjFhJ",
+      "symbol": "MOON",
+      "name": "MoonSol",
+      "decimals": 4,
+      "logoURI": "https://lizardtoken.xyz/gallery/moon-ts1635027621.jpg",
+      "tags": [],
+      "extensions": {
+        "website": "https://moonsol.xyz"
+      }
     },
-	  {
-	    "chainId": 101,
-	    "address": "E1zxRweqCWzviAraKjNjqupuyYTzm1bukJgb8KiBN1sN",
-	    "symbol": "GOLD",
-	    "name": "SolGold",
-	    "decimals": 5,
-	    "logoURI": "https://lizardtoken.xyz/gallery/gold-ts1635027612.jpg",
-	    "tags": [],
-	    "extensions": {
-	      "website": "https://solgold.xyz"
-	    }
+    {
+      "chainId": 101,
+      "address": "E1zxRweqCWzviAraKjNjqupuyYTzm1bukJgb8KiBN1sN",
+      "symbol": "GOLD",
+      "name": "SolGold",
+      "decimals": 5,
+      "logoURI": "https://lizardtoken.xyz/gallery/gold-ts1635027612.jpg",
+      "tags": [],
+      "extensions": {
+        "website": "https://solgold.xyz"
+      }
     },
     {
       "chainId": 101,
@@ -21748,7 +21809,9 @@
       "name": "MoppelCoin",
       "decimals": 9,
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/assets/E5H5mHzUA8pRSL4X2ovv4sZMSorYk56EtCbQExQveRGJ/logo.png",
-      "tags": ["coin"],
+      "tags": [
+        "coin"
+      ],
       "extensions": {
         "website": "https://sites.google.com/view/moppelcoin/startseite"
       }
@@ -21760,7 +21823,9 @@
       "name": "StarSnuppy",
       "decimals": 9,
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/9xtsYLJjGhwKHxoZf1XU519bwSzwC4gf3XSVy9wZLpNz/logo.png",
-      "tags": ["coin"],
+      "tags": [
+        "coin"
+      ],
       "extensions": {
         "website": "https://starsnuppy.wordpress.com/"
       }
@@ -21772,7 +21837,12 @@
       "name": "Jetson",
       "decimals": 9,
       "logoURI": "https://i.ibb.co/8zcfqM3/jetson.jpg",
-      "tags": ["coin", "AI", "IoT", "Automation"],
+      "tags": [
+        "coin",
+        "AI",
+        "IoT",
+        "Automation"
+      ],
       "extensions": {
         "website": "https://www.jetson.ai/"
       }
@@ -21849,19 +21919,19 @@
         "website": "http://www.thehae.biz"
       }
     },
-    {                                                                                
-        "chainId": 101,                                                                
-        "address": "6TDmspddJYcaBB3Cce3XN6LbJheFjWsMJ5dfLoXvEgyJ",                     
-        "symbol": "SUMMYBIKE",                                                         
-        "name": "Sumarokov my bike token",                                             
-        "decimals": 0,                                                                 
-        "logoURI": "https://github.com/solana-labs/token-list/raw/assets/mainnet/6TDmspddJYcaBB3Cce3XN6LbJheFjWsMJ5dfLoXvEgyJ/SUMMYBIKE.png",           
-        "tags": [                                                                      
-          "nft"                                                                        
-        ],                                                                             
-        "extensions": {                                                                
-          "telegram": "https://t.me/sumarokov_cyclist"                                 
-        }                                                                              
+    {
+      "chainId": 101,
+      "address": "6TDmspddJYcaBB3Cce3XN6LbJheFjWsMJ5dfLoXvEgyJ",
+      "symbol": "SUMMYBIKE",
+      "name": "Sumarokov my bike token",
+      "decimals": 0,
+      "logoURI": "https://github.com/solana-labs/token-list/raw/assets/mainnet/6TDmspddJYcaBB3Cce3XN6LbJheFjWsMJ5dfLoXvEgyJ/SUMMYBIKE.png",
+      "tags": [
+        "nft"
+      ],
+      "extensions": {
+        "telegram": "https://t.me/sumarokov_cyclist"
+      }
     },
     {
       "chainId": 101,
@@ -21882,10 +21952,10 @@
       "decimals": 9,
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/GRoESmA4DZjd7MMgvzaDaswZHow75ies6Xje5FoXytDP/logo.png",
       "tags": [
-         "VOO-token"
+        "VOO-token"
       ],
       "extensions": {
-         "website": "https://www.voovoo.io"
+        "website": "https://www.voovoo.io"
       }
     },
     {
@@ -21942,7 +22012,7 @@
         "description": "Become the hodl champion."
       }
     },
-{
+    {
       "chainId": 101,
       "address": "3dmtKhD4bGXXdticPXyEeV3WF3mHcEucpSyJbUZum5cG",
       "symbol": "CSFCOIN",
@@ -22006,7 +22076,7 @@
       "extensions": {
         "website": "https://www.kisscrypto.net/",
         "whitepaper": "https://ae283fe9-fab9-4865-a65a-bcd5559ada09.filesusr.com/ugd/0a74e1_8d61680fa97d40568d9f7adba2eccfd7.pdf"
-      } 
+      }
     },
     {
       "chainId": 101,
@@ -22024,21 +22094,24 @@
         "twitter": "https://twitter.com/trashypandasNFT"
       }
     },
-{
-        "chainId": 101,
-        "address": "SAMUmmSvrE8yqtcG94oyP1Zu2P9t8PSRSV3vewsGtPM",
-        "symbol": "SAMU",
-        "name": "Samusky Token",
-        "decimals": 9,
-        "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/SAMUmmSvrE8yqtcG94oyP1Zu2P9t8PSRSV3vewsGtPM/logo.png",
-        "tags": ["social-token", "community-token"],
-        "extensions": {
-          "website": "https://samusky.io",
-          "twitter": "https://twitter.com/samuskyio",
-          "github": "https://github.com/samuskyio",
-          "telegram": "https://t.me/samuskyio"
-        }
-      },
+    {
+      "chainId": 101,
+      "address": "SAMUmmSvrE8yqtcG94oyP1Zu2P9t8PSRSV3vewsGtPM",
+      "symbol": "SAMU",
+      "name": "Samusky Token",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/SAMUmmSvrE8yqtcG94oyP1Zu2P9t8PSRSV3vewsGtPM/logo.png",
+      "tags": [
+        "social-token",
+        "community-token"
+      ],
+      "extensions": {
+        "website": "https://samusky.io",
+        "twitter": "https://twitter.com/samuskyio",
+        "github": "https://github.com/samuskyio",
+        "telegram": "https://t.me/samuskyio"
+      }
+    },
     {
       "chainId": 101,
       "address": "27NnGuWWsJ2aJvG85D27eiYBCcfc8LcFcvuW5yHM6gSz",
@@ -22047,8 +22120,8 @@
       "decimals": 9,
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/27NnGuWWsJ2aJvG85D27eiYBCcfc8LcFcvuW5yHM6gSz/logo.png",
       "tags": [
-          "trash",
-          "testing"
+        "trash",
+        "testing"
       ],
       "extensions": {}
     },
@@ -22082,7 +22155,7 @@
         "twitter": "https://twitter.com/SolanaWorms"
       }
     },
-	{
+    {
       "chainId": 103,
       "address": "9vXqVi6UsD9JZwzfZoyQmVusCeUWPv1D1ZcWTpX5hxDu",
       "symbol": "GHT",
@@ -22099,8 +22172,8 @@
         "youtube": "https://www.youtube.com/channel/UCmRkuXFFDYe5ISENoCkO6AA",
         "twitter": "https://twitter.com/bitexcer"
       }
-	},
-	{
+    },
+    {
       "chainId": 101,
       "address": "7s5A6XukBCsM7S4EtHsNFzQfvztRdwZWGn1pQwQYfWBm",
       "symbol": "CERT",
@@ -22116,7 +22189,7 @@
         "twitter": "https://twitter.com/identicert"
       }
     },
-	{
+    {
       "chainId": 101,
       "address": "ALbwwCnYj5Mf8S7k4QTSqezLbTMmpVdrv2SMYJTu4v9W",
       "symbol": "IDEN",
@@ -22225,8 +22298,7 @@
       "extensions": {
         "website": "https://cropper.finance/farms/"
       }
-    }
-    ,
+    },
     {
       "chainId": 101,
       "address": "8WR1cJ2RvcqFMNpsaBdUHamsibv8ywcCwmUAMg6ob1Xo",
@@ -22241,9 +22313,9 @@
       "extensions": {
         "website": "https://www.vibratinghamster.com/",
         "twitter": "https://twitter.com/vibratinghamstr",
-        "discord":  "https://discord.gg/7Z4XbB7bDu"
+        "discord": "https://discord.gg/7Z4XbB7bDu"
       }
-    },    
+    },
     {
       "chainId": 101,
       "address": "HM9jjC8gThNDfFv3TRWqUdfJp5onWGDXhWirm5sUcFhj",
@@ -22275,8 +22347,7 @@
         "website": "https://dogesol.com/",
         "twitter": "https://twitter.com/Doge_Solana"
       }
-    }
-	,
+    },
     {
       "chainId": 101,
       "address": "CuEi5x3nzHcCmiyG7CMPRiKNBhGKt9gyUtXkPK347eqa",
@@ -22294,7 +22365,7 @@
       "extensions": {
         "twitter": "https://twitter.com/solbark"
       }
-    },    
+    },
     {
       "chainId": 101,
       "address": "9Exx2WQUZkRwbLB9RxSVThGdkuYdgCWW3v7GgDbFYR3c",
@@ -22309,7 +22380,7 @@
         "Pig Lad"
       ],
       "extensions": {}
-    },    
+    },
     {
       "chainId": 101,
       "address": "xAx6d1sjmBvpWkVZQEqgUvPmGBNndEXPxYpr3QVp61H",
@@ -22392,26 +22463,24 @@
       "logoURI": "https://raw.githubusercontent.com/solanadevv/token-list/assets/mainnet/CE6gowswLbhy5y9G2EDfvYSavAcdSaqX3wMta5gySG1H/logo.png",
       "tags": [
         "Meme-Token",
-    
         "nft"
       ],
       "extensions": {
-      
         "twitter": "https://twitter.com/BullDogSolana"
       }
     },
-	 {
+    {
       "chainId": 101,
       "address": "3jzdrXXKxwkBk82u2eCWASZLCKoZs1LQTg87HBEAmBJw",
       "symbol": "FLOOF",
       "name": "FLOOF",
       "decimals": 9,
       "logoURI": "https://github.com/GreenFailure/Floof/blob/b928ee6640e28695100b3bf5b1c98d74add84301/istockphoto-1303160539-612x612.jpg",
-	  "logoURI": "https://raw.githubusercontent.com/GreenFailure/Floof/b928ee6640e28695100b3bf5b1c98d74add84301/istockphoto-1303160539-612x612.jpg",
-	  "logoURI": "https://raw.githubusercontent.com/GreenFailure/Floof/main/OkyT9kpz_400x400.png",
+      "logoURI": "https://raw.githubusercontent.com/GreenFailure/Floof/b928ee6640e28695100b3bf5b1c98d74add84301/istockphoto-1303160539-612x612.jpg",
+      "logoURI": "https://raw.githubusercontent.com/GreenFailure/Floof/main/OkyT9kpz_400x400.png",
       "tags": [],
-	  "coingeckoId": "floof",
-	  "serumV3Usdc": "BxcuT1p8FK9cFak4Uuf5nmoAZ7nQGu7FerCMESGqxF7b",
+      "coingeckoId": "floof",
+      "serumV3Usdc": "BxcuT1p8FK9cFak4Uuf5nmoAZ7nQGu7FerCMESGqxF7b",
       "extensions": {
         "website": "www.floofsolana.com",
         "twitter": "https://twitter.com/FLOOF_SOLANA",
@@ -22432,7 +22501,7 @@
         "website": "https://pantie.app/"
       }
     },
-{
+    {
       "chainId": 101,
       "address": "58yYYVT5FoVx2jtvD9xtX4JxE8jogtA5tjMkJudgERMS",
       "symbol": "DONKEY",
@@ -22456,10 +22525,8 @@
         "Validator",
         "Columbus.inc"
       ]
-    }
-
-,
-	{
+    },
+    {
       "chainId": 101,
       "address": "Uuc6hiKT9Y6ASoqs2phonGGw2LAtecfJu9yEohppzWH",
       "symbol": "BABY",
@@ -22467,15 +22534,15 @@
       "decimals": 9,
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/Uuc6hiKT9Y6ASoqs2phonGGw2LAtecfJu9yEohppzWH/logo.png",
       "tags": [
-      "community-token"
+        "community-token"
       ],
       "extensions": {
         "website": "https://www.babysamocoin.com/",
         "twitter": "https://twitter.com/BabySamoCoin",
         "discord": "https://discord.gg/RhQTNhRk2X"
       }
-   },
-   {
+    },
+    {
       "chainId": 101,
       "address": "MSQTxnsq8t94gEqZ42a6mxuw11LBYWF4J5hy84GaECb",
       "symbol": "MSQ",
@@ -22492,191 +22559,189 @@
         "discord": "https://discord.com/invite/u9SHXU9qNd",
         "medium": "https://medium.com/@magicsquare"
       }
-   }
-,
- {
-    "chainId": 101,
-    "address": "AsVNhq2nnoUgMWciCvePRyHk7xAv6i4ruV6oRHFWBcwF",
-    "symbol": "SHIBL",
-    "name": "Shibalana Inu",
-    "decimals": 9,
-    "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/AsVNhq2nnoUgMWciCvePRyHk7xAv6i4ruV6oRHFWBcwF/logo.png",
-    "tags": [
-    "community-token", "meme-token", "doge","dogecoin"
-    ],
-    "extensions": {
-      "twitter": "https://twitter.com/shibalana_inu"
-, "website" : "https://trade.dexlab.space/#/market/Fc5co91LY2tiZAVuvCmVxDFZWA9SVBVLuxpBcYRQbH1T"
-    }
-   }
-   ,
-   {
-    "chainId": 101,
-    "address": "FmQN1sQDeD9DF7aQvmJA9zZ8hicJYxUzzCDSnV8tfUtY",
-    "symbol": "NOOT",
-    "name": "NOOT Coin",
-    "decimals": 9,
-    "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/FmQN1sQDeD9DF7aQvmJA9zZ8hicJYxUzzCDSnV8tfUtY/noot.png",
-    "tags": [
-      "Meme-Token"
-    ]
- }  
-,
-{
-  "chainId": 101,
-  "address": "FucvfR9FF2xsRaGbzrhywNsfxsx2fjoJLEckUDJALG62",
-  "symbol": "BADURUS",
-  "name": "BaduroCoin",
-  "decimals": 9,
-  "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/FucvfR9FF2xsRaGbzrhywNsfxsx2fjoJLEckUDJALG62/logo.png",
-  "tags": [
-    "gambling-token",
-    "meme-token"
-  ],
-  "extensions": {
-    "twitter": "https://twitter.com/badurocoin",
-    "website": "https://badurocoin.pl",
-    "github": "https://github.com/BaduroCoin"
-  }
-}
-,
-{
-    "chainId": 101,
-    "address": "SLNDpmoWTVADgEdndyvWzroNL7zSi1dF9PC3xHGtPwp",
-    "symbol": "SLND",
-    "name": "Solend",
-    "decimals": 6,
-    "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/SLNDpmoWTVADgEdndyvWzroNL7zSi1dF9PC3xHGtPwp/logo.png",
-    "tags": [
-      "solend",
-      "lending"
-    ],
-    "extensions": {
-      "coingeckoId": "solend",
-      "twitter": "https://twitter.com/solendprotocol",
+    },
+    {
+      "chainId": 101,
+      "address": "AsVNhq2nnoUgMWciCvePRyHk7xAv6i4ruV6oRHFWBcwF",
+      "symbol": "SHIBL",
+      "name": "Shibalana Inu",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/AsVNhq2nnoUgMWciCvePRyHk7xAv6i4ruV6oRHFWBcwF/logo.png",
+      "tags": [
+        "community-token",
+        "meme-token",
+        "doge",
+        "dogecoin"
+      ],
+      "extensions": {
+        "twitter": "https://twitter.com/shibalana_inu",
+        "website": "https://trade.dexlab.space/#/market/Fc5co91LY2tiZAVuvCmVxDFZWA9SVBVLuxpBcYRQbH1T"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "FmQN1sQDeD9DF7aQvmJA9zZ8hicJYxUzzCDSnV8tfUtY",
+      "symbol": "NOOT",
+      "name": "NOOT Coin",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/FmQN1sQDeD9DF7aQvmJA9zZ8hicJYxUzzCDSnV8tfUtY/noot.png",
+      "tags": [
+        "Meme-Token"
+      ]
+    },
+    {
+      "chainId": 101,
+      "address": "FucvfR9FF2xsRaGbzrhywNsfxsx2fjoJLEckUDJALG62",
+      "symbol": "BADURUS",
+      "name": "BaduroCoin",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/FucvfR9FF2xsRaGbzrhywNsfxsx2fjoJLEckUDJALG62/logo.png",
+      "tags": [
+        "gambling-token",
+        "meme-token"
+      ],
+      "extensions": {
+        "twitter": "https://twitter.com/badurocoin",
+        "website": "https://badurocoin.pl",
+        "github": "https://github.com/BaduroCoin"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "SLNDpmoWTVADgEdndyvWzroNL7zSi1dF9PC3xHGtPwp",
+      "symbol": "SLND",
+      "name": "Solend",
+      "decimals": 6,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/SLNDpmoWTVADgEdndyvWzroNL7zSi1dF9PC3xHGtPwp/logo.png",
+      "tags": [
+        "solend",
+        "lending"
+      ],
+      "extensions": {
+        "coingeckoId": "solend",
+        "twitter": "https://twitter.com/solendprotocol",
         "website": "https://solend.fi"
-
-    }
-},
-{
-    "chainId": 101,
-    "address": "6wFgUMohoSavTuEneDYcrb9qF3JsYVVXyB8jb3PaXCJ4",
-    "symbol": "Kishu",
-    "name": "Kishu Inu",
-    "decimals": 9,
-    "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/6wFgUMohoSavTuEneDYcrb9qF3JsYVVXyB8jb3PaXCJ4/logo.png",
-    "tags": [
-    "community-token", "meme-token", "doge","dogecoin", "kishu inu"
-    ],
-    "extensions": {
-      "twitter": "https://twitter.com/ShibamoonNFT",
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "6wFgUMohoSavTuEneDYcrb9qF3JsYVVXyB8jb3PaXCJ4",
+      "symbol": "Kishu",
+      "name": "Kishu Inu",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/6wFgUMohoSavTuEneDYcrb9qF3JsYVVXyB8jb3PaXCJ4/logo.png",
+      "tags": [
+        "community-token",
+        "meme-token",
+        "doge",
+        "dogecoin",
+        "kishu inu"
+      ],
+      "extensions": {
+        "twitter": "https://twitter.com/ShibamoonNFT",
         "website": "https://www.shibamoon.info/"
-
-    }
-}
-,
-{
-  "chainId": 101,
-  "address": "FZBNaVMz5n1EcKfno8Jgsa2go5GLUwBYVpGPvKAdzNth",
-  "symbol": "PONQUE",
-  "name": "Ponque Coin",
-  "decimals": 9,
-  "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/FZBNaVMz5n1EcKfno8Jgsa2go5GLUwBYVpGPvKAdzNth/logo.png",
-  "tags": [
-    "community-token",
-    "utility-token",
-    "capys",
-    "ponque coin"
-  ],
-  "extensions": {
-    "twitter": "https://twitter.com/solcapys",
-    "website": "https://www.solcapys.club/"
-  }
-}
-,
-{
-  "chainId": 101,
-  "address": "cqNTpypmbwghrf1G9VGvSENcw7M7wGSQ7JS8UTQWXwb",
-  "symbol": "SCUM",
-  "name": "Solana CUM",
-  "decimals": 8,
-  "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/cqNTpypmbwghrf1G9VGvSENcw7M7wGSQ7JS8UTQWXwb/logo.png",
-  "tags": [
-    "community-token",
-    "solana cum",
-    "cum"
-  ],
-  "extensions": {
-    "twitter": "https://twitter.com/SolanaCum",
-    "website": "https://www.solanacum.com/"
-  }
-}
-,
-{
-  "chainId": 101,
-  "address": "8E5W9PMhnEvdvM2Q9XBLMJW7UsFiieXnRHPj8zhtB23h",
-  "symbol": "APPLE",
-  "name": "Apple Fruit",
-  "decimals": 9,
-  "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/8E5W9PMhnEvdvM2Q9XBLMJW7UsFiieXnRHPj8zhtB23h/logo.png",
-  "tags": [
-    "community-token",
-    "meme-coin",
-    "fruit",
-    "apple-coin"
-  ],
-  "extensions": {
-    "website": "https://superfruit.farm",
-    "discord": "https://discord.gg/NfGXqUTV",
-    "twitter": "https://twitter.com/superfruitnft"
-  }
-}
-,
-{
-  "chainId": 101,
-  "address": "2qRHKgE9k7doshwy7ZfENuSHW256pDhcbyspDgU3Ek8C",
-  "symbol": "SAMOL",
-  "name": "Samolana NFT",
-  "decimals": 9,
-  "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/2qRHKgE9k7doshwy7ZfENuSHW256pDhcbyspDgU3Ek8C/logo.png",
-  "tags": [
-    "meme", "community","NFTs","DEFI",
-      "Dog"
-  ],
-  "extensions": {
-    "twitter": "https://twitter.com/samolana3"
-  }
-}
-,
-{
-  "chainId": 101,
-  "address": "25DXQbnQicHzZ6sH4HgbhpEGUahxEPZUkPkFbU2Jr7D3",
-  "symbol": "CLICK",
-  "name": "Nice Click",
-  "decimals": 9,
-  "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/25DXQbnQicHzZ6sH4HgbhpEGUahxEPZUkPkFbU2Jr7D3/logo.png",
-  "tags": [
-    "meme-token"
-  ],
-  "extensions": {
-    "twitter": "https://twitter.com/proofofclick",
-    "website": "https://www.proofofclick.com/"
-  }
-},
-{
-  "chainId": 101,
-  "address": "CDxwZo3ayxvTmxin7F6o9xg6SjdE4qWEDXV6MZFBevqw",
-  "symbol": "SHIBS",
-  "name": "ShibSol",
-  "decimals": 9,
-  "logoURI": "https://discordapp.com/channels/@me/903775821704073247/903777435231846420",
-  "tags": [],
-  "extensions": {
-    "website": "https://www.solshib.net/",
-    "twitter": "https://twitter.com/ShibSol"
-  }
-}
-,
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "FZBNaVMz5n1EcKfno8Jgsa2go5GLUwBYVpGPvKAdzNth",
+      "symbol": "PONQUE",
+      "name": "Ponque Coin",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/FZBNaVMz5n1EcKfno8Jgsa2go5GLUwBYVpGPvKAdzNth/logo.png",
+      "tags": [
+        "community-token",
+        "utility-token",
+        "capys",
+        "ponque coin"
+      ],
+      "extensions": {
+        "twitter": "https://twitter.com/solcapys",
+        "website": "https://www.solcapys.club/"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "cqNTpypmbwghrf1G9VGvSENcw7M7wGSQ7JS8UTQWXwb",
+      "symbol": "SCUM",
+      "name": "Solana CUM",
+      "decimals": 8,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/cqNTpypmbwghrf1G9VGvSENcw7M7wGSQ7JS8UTQWXwb/logo.png",
+      "tags": [
+        "community-token",
+        "solana cum",
+        "cum"
+      ],
+      "extensions": {
+        "twitter": "https://twitter.com/SolanaCum",
+        "website": "https://www.solanacum.com/"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "8E5W9PMhnEvdvM2Q9XBLMJW7UsFiieXnRHPj8zhtB23h",
+      "symbol": "APPLE",
+      "name": "Apple Fruit",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/8E5W9PMhnEvdvM2Q9XBLMJW7UsFiieXnRHPj8zhtB23h/logo.png",
+      "tags": [
+        "community-token",
+        "meme-coin",
+        "fruit",
+        "apple-coin"
+      ],
+      "extensions": {
+        "website": "https://superfruit.farm",
+        "discord": "https://discord.gg/NfGXqUTV",
+        "twitter": "https://twitter.com/superfruitnft"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "2qRHKgE9k7doshwy7ZfENuSHW256pDhcbyspDgU3Ek8C",
+      "symbol": "SAMOL",
+      "name": "Samolana NFT",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/2qRHKgE9k7doshwy7ZfENuSHW256pDhcbyspDgU3Ek8C/logo.png",
+      "tags": [
+        "meme",
+        "community",
+        "NFTs",
+        "DEFI",
+        "Dog"
+      ],
+      "extensions": {
+        "twitter": "https://twitter.com/samolana3"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "25DXQbnQicHzZ6sH4HgbhpEGUahxEPZUkPkFbU2Jr7D3",
+      "symbol": "CLICK",
+      "name": "Nice Click",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/25DXQbnQicHzZ6sH4HgbhpEGUahxEPZUkPkFbU2Jr7D3/logo.png",
+      "tags": [
+        "meme-token"
+      ],
+      "extensions": {
+        "twitter": "https://twitter.com/proofofclick",
+        "website": "https://www.proofofclick.com/"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "CDxwZo3ayxvTmxin7F6o9xg6SjdE4qWEDXV6MZFBevqw",
+      "symbol": "SHIBS",
+      "name": "ShibSol",
+      "decimals": 9,
+      "logoURI": "https://discordapp.com/channels/@me/903775821704073247/903777435231846420",
+      "tags": [],
+      "extensions": {
+        "website": "https://www.solshib.net/",
+        "twitter": "https://twitter.com/ShibSol"
+      }
+    },
     {
       "chainId": 101,
       "address": "3tufRsMkBu5rYUCsSQys3ZjBXxXLWeRgttAXX4a1CDdW",
@@ -22684,7 +22749,9 @@
       "name": "Gawd Token",
       "decimals": 9,
       "logoURI": "https://cdn.jsdelivr.net/gh/MaloSkylar/GAWDtoken/GAWDlogo.jpg",
-      "tags": ["Social-Coin"],
+      "tags": [
+        "Social-Coin"
+      ],
       "extensions": {
         "website": ""
       }
@@ -22716,8 +22783,8 @@
       "decimals": 5,
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/G7uwQLyFLpeKWZePU3q5eCMuQYcu3tMoGZvu3JHdksyW/logo.png"
     },
-	{
-   "chainId": 101,
+    {
+      "chainId": 101,
       "address": "A9UhP1xfQHWUhSd54NgKPub2XB3ZuQMdPEvf9aMTHxGT",
       "symbol": "DEGN",
       "name": "Degen",
@@ -22725,7 +22792,7 @@
       "logoURI": "https://raw.githubusercontent.com/flazewang/degencoinsolana/main/degen.png",
       "tags": [],
       "extensions": {
-          "twitter": "https://twitter.com/degencoinsol"
+        "twitter": "https://twitter.com/degencoinsol"
       }
     },
     {
@@ -22736,7 +22803,9 @@
       "decimals": 9,
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/H6JocWxg5g1Lcs4oPnBecmjQ4Y1bkZhGJHtjMunmjyrp/logo.png",
       "tags": [
-        "meme-token", "community-token", "trading-token"
+        "meme-token",
+        "community-token",
+        "trading-token"
       ],
       "extensions": {
         "website": "https://sphinxel.com",
@@ -22753,7 +22822,7 @@
       "tags": [],
       "extensions": {
         "twitter": "https://twitter.com/DatalusCorp",
-	      "website": "https://datalus.us"
+        "website": "https://datalus.us"
       }
     },
     {
@@ -22771,8 +22840,7 @@
         "website": "https://www.solafinger.com/",
         "twitter": "https://twitter.com/solafinger"
       }
-    }
-    ,
+    },
     {
       "chainId": 101,
       "address": "PEGDAG5KpGAw66WBeGJcwub17eAyb9A4iFhBADsDJjF",
@@ -22789,8 +22857,7 @@
         "telegram": "https://t.me/teamsolanim",
         "twitter": "https://twitter.com/teamsolanim"
       }
-    }
-    ,
+    },
     {
       "chainId": 101,
       "address": "3Z5o6GGjkzPgBVk7aFPsTGFPqGDdAwXjfGteuQa1SE95",
@@ -22806,8 +22873,7 @@
         "website": "https://www.solaghosts.io",
         "twitter": "https://twitter.com/solaghosts"
       }
-    }
-    ,
+    },
     {
       "chainId": 101,
       "address": "7CskY61wSZUZeSoMNHHX6br9kA9hL9v5EwAkS6mqsYNc",
@@ -22819,191 +22885,195 @@
       "extensions": {
         "website": "https://projectdumpling.com/"
       }
-  }
-  ,
+    },
     {
-          "chainId": 101,
-          "address": "3jv3yRRX2WgBLeUe7p7AFxazudp913CK6BRk9aHCCUxz",
-          "symbol": "MOGUL",
-          "name": "Mogul coin",
-          "decimals": 9,
-          "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/3jv3yRRX2WgBLeUe7p7AFxazudp913CK6BRk9aHCCUxz/logo.png",
-          "tags": [
-            "meme-token"
-          ],
-          "extensions": {
-            "twitter": "https://twitter.com/MogulWars"
-          }
-        }
-,
-        {
-          "chainId": 101,
-          "address": "9bpJThLhAar7PkK61apHP35pRMm24MHGijCRZTUK8A3b",
-          "symbol": "ABTC",
-          "name": "ArabicBitCoin",
-          "decimals": 8,
-          "logoURI": "https://cdn.jsdelivr.net/gh/ArabicBitCoin/ABTC/ABTC-logo.png",
-          "tags": [
-	    "utility-token",
-	    "lp-token",
-            "Arabic BitCoin",
-            "Arabic",
-            "Arab",
-            "Arabic Token"
-	    ,"utility-token",
-	    "lp-token"
-          ],
-          "extensions": {
-            "website": "http://arabicabitcoin.com/",
-            "twitter": "https://twitter.com/ArabicaBitcoin"
-          }
-        },
-        {
-          "chainId": 101,
-          "address": "4evENxfLeUDk24nrqzMp4gkR3kPxCMeQuCeftjgd66BD",
-          "symbol": "SBOOBS",
-          "name": "Solana Boobs",
-          "decimals": 9,
-          "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/4evENxfLeUDk24nrqzMp4gkR3kPxCMeQuCeftjgd66BD/logo.jpg",
-          "tags": [
-            "utility-token"
-          ],
-          "extensions": {
-            "website": "https://www.solanaboobs.com/",
-            "twitter": "https://twitter.com/solanaboobs"
-          }
-        }
-        ,
-        {
-          "chainId":101,
-          "address":"RdFHYW7mPJouuSpb5vEzUfbHeQedmQMuCoHN4VQkUDn",
-          "symbol":"LUCHOW",
-          "name":"LunaChow",
-          "decimals":8,
-          "logoURI":"https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/RdFHYW7mPJouuSpb5vEzUfbHeQedmQMuCoHN4VQkUDn/logo.png",
-          "tags":[
-             "wrapped",
-             "wormhole"
-          ],
-          "extensions":{
-             "website":"https://www.lunachow.com/",
-             "address":"0xa5ef74068d04ba0809b7379dd76af5ce34ab7c57",
-             "bridgeContract":"https://etherscan.io/address/0x3ee18B2214AFF97000D974cf647E7C347E8fa585",
-             "assetContract":"https://etherscan.io/address/0xa5ef74068d04ba0809b7379dd76af5ce34ab7c57",
-             "coingeckoId":"lunachow",
-             "reddit":"https://www.reddit.com/r/lunachow/",
-             "twitter":"https://twitter.com/LunaChoww",
-             "discord":"https://discord.gg/FBz7dGkxgv",
-             "facebook":"https://www.facebook.com/LunaChowOfficial",
-             "instagram":"https://www.instagram.com/lunachow.io/",
-             "telegram":"https://t.me/LuChow"
-          }
-       }
-        ,
-        {
-          "chainId":101,
-          "address":"3mZMtzsr11srDX7jdpkacsxAo1Na5H4kqepxehjhTkLE",
-          "symbol":"LUCHOW",
-          "name":"LunaChow",
-          "decimals":8,
-          "logoURI":"https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/3mZMtzsr11srDX7jdpkacsxAo1Na5H4kqepxehjhTkLE/logo.png",
-          "tags":[
-             "wrapped",
-             "wormhole"
-          ],
-          "extensions":{
-             "website":"https://www.lunachow.com/",
-             "address":"0xa5ef74068d04ba0809b7379dd76af5ce34ab7c57",
-             "bridgeContract":"https://etherscan.io/address/0x3ee18B2214AFF97000D974cf647E7C347E8fa585",
-             "assetContract":"https://etherscan.io/address/0xa5ef74068d04ba0809b7379dd76af5ce34ab7c57",
-             "coingeckoId":"lunachow",
-             "reddit":"https://www.reddit.com/r/lunachow/",
-             "twitter":"https://twitter.com/LunaChoww",
-             "discord":"https://discord.gg/FBz7dGkxgv",
-             "facebook":"https://www.facebook.com/LunaChowOfficial",
-             "instagram":"https://www.instagram.com/lunachow.io/",
-             "telegram":"https://t.me/LuChow"
-          }
-       }
-,{
-          "chainId": 101,
-          "address": "9k27FY1wmxKEyoMGqK4zJMT2Y8dvkiYRGM2ijjLLTrjq",
-          "symbol": "UNIVERSE",
-          "name": "universe",
-          "decimals": 8,
-          "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/9k27FY1wmxKEyoMGqK4zJMT2Y8dvkiYRGM2ijjLLTrjq/logo.png",
-          "tags": [
-            "Metaverse",
-            "Universe"
-          ],
-          "extensions": {
-          }
-        }
-		,{
-          "chainId": 101,
-          "address": "CA3XWNSEQNtBiiWQE9CQJp5G93eAZKZF7j6wx9tMTZR7",
-          "symbol": "CHEEZ",
-          "name": "Cheezburger",
-          "decimals": 9,
-          "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/CA3XWNSEQNtBiiWQE9CQJp5G93eAZKZF7j6wx9tMTZR7/logo.png",
-          "tags": [
-            "social-token",
-            "meme-token"
-          ],
-          "extensions": {
-          }
-        }
-,{
-          "chainId": 101,
-          "address": "6kr8q1SXXNRLy3imzDsecWkcRtzJiXqiXx1N7LtpMPTe",
-          "symbol": "BIT",
-          "name": "Biconomy Token",
-          "decimals": 9,
-          "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/6kr8q1SXXNRLy3imzDsecWkcRtzJiXqiXx1N7LtpMPTe/logo.png",
-          "tags": ["exchange-token"],
-          "extensions": {
-            "bridgeContract": "https://bscscan.com/token/0xc864019047B864B6ab609a968ae2725DFaee808A",
-            "website": "https://biconomy.com",
-            "coingeckoId": "biconomy-exchange-token"
-          }
-        }
-,{
-          "chainId": 101,
-          "address": "EFBGjiTEuvhwZGmEzDBJwrWnSDuALx94MERncXNsap3G",
-          "symbol": "RBTP",
-          "name": "Robotopian Token",
-          "decimals": 9,
-          "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/EFBGjiTEuvhwZGmEzDBJwrWnSDuALx94MERncXNsap3G/logo.png",
-          "tags": ["utility-token"],
-          "extensions": {
-            "website": "https://robotopia.io"
-          }
-        }
-,{
-          "chainId": 101,
-          "address": "7tfCwa3CCNzhvLCkKPaBWvYxyjq157Wha1EDKZJAxBZ",
-          "symbol": "RBTK",
-          "name": "Robotopian Token",
-          "decimals": 9,
-          "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/7tfCwa3CCNzhvLCkKPaBWvYxyjq157Wha1EDKZJAxBZ/logo.png",
-          "tags": ["utility-token"],
-          "extensions": {
-            "website": "https://robotopia.io"
-          }
-        }
-,{
-          "chainId": 101,
-          "address": "Dm3qVmVLAEQPSHoHCzAuF1gpmT2k2SXe1Pw2FgtUVAaC",
-          "symbol": "DNG",
-          "name": "DNG Reasearch Token",
-          "decimals": 9,
-          "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/Dm3qVmVLAEQPSHoHCzAuF1gpmT2k2SXe1Pw2FgtUVAaC/logo.png",
-          "tags": ["social-token"],
-          "extensions": {
-            "website": "http://d-n-g.io/"
-          }
-        }
-,{
+      "chainId": 101,
+      "address": "3jv3yRRX2WgBLeUe7p7AFxazudp913CK6BRk9aHCCUxz",
+      "symbol": "MOGUL",
+      "name": "Mogul coin",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/3jv3yRRX2WgBLeUe7p7AFxazudp913CK6BRk9aHCCUxz/logo.png",
+      "tags": [
+        "meme-token"
+      ],
+      "extensions": {
+        "twitter": "https://twitter.com/MogulWars"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "9bpJThLhAar7PkK61apHP35pRMm24MHGijCRZTUK8A3b",
+      "symbol": "ABTC",
+      "name": "ArabicBitCoin",
+      "decimals": 8,
+      "logoURI": "https://cdn.jsdelivr.net/gh/ArabicBitCoin/ABTC/ABTC-logo.png",
+      "tags": [
+        "utility-token",
+        "lp-token",
+        "Arabic BitCoin",
+        "Arabic",
+        "Arab",
+        "Arabic Token",
+        "utility-token",
+        "lp-token"
+      ],
+      "extensions": {
+        "website": "http://arabicabitcoin.com/",
+        "twitter": "https://twitter.com/ArabicaBitcoin"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "4evENxfLeUDk24nrqzMp4gkR3kPxCMeQuCeftjgd66BD",
+      "symbol": "SBOOBS",
+      "name": "Solana Boobs",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/4evENxfLeUDk24nrqzMp4gkR3kPxCMeQuCeftjgd66BD/logo.jpg",
+      "tags": [
+        "utility-token"
+      ],
+      "extensions": {
+        "website": "https://www.solanaboobs.com/",
+        "twitter": "https://twitter.com/solanaboobs"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "RdFHYW7mPJouuSpb5vEzUfbHeQedmQMuCoHN4VQkUDn",
+      "symbol": "LUCHOW",
+      "name": "LunaChow",
+      "decimals": 8,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/RdFHYW7mPJouuSpb5vEzUfbHeQedmQMuCoHN4VQkUDn/logo.png",
+      "tags": [
+        "wrapped",
+        "wormhole"
+      ],
+      "extensions": {
+        "website": "https://www.lunachow.com/",
+        "address": "0xa5ef74068d04ba0809b7379dd76af5ce34ab7c57",
+        "bridgeContract": "https://etherscan.io/address/0x3ee18B2214AFF97000D974cf647E7C347E8fa585",
+        "assetContract": "https://etherscan.io/address/0xa5ef74068d04ba0809b7379dd76af5ce34ab7c57",
+        "coingeckoId": "lunachow",
+        "reddit": "https://www.reddit.com/r/lunachow/",
+        "twitter": "https://twitter.com/LunaChoww",
+        "discord": "https://discord.gg/FBz7dGkxgv",
+        "facebook": "https://www.facebook.com/LunaChowOfficial",
+        "instagram": "https://www.instagram.com/lunachow.io/",
+        "telegram": "https://t.me/LuChow"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "3mZMtzsr11srDX7jdpkacsxAo1Na5H4kqepxehjhTkLE",
+      "symbol": "LUCHOW",
+      "name": "LunaChow",
+      "decimals": 8,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/3mZMtzsr11srDX7jdpkacsxAo1Na5H4kqepxehjhTkLE/logo.png",
+      "tags": [
+        "wrapped",
+        "wormhole"
+      ],
+      "extensions": {
+        "website": "https://www.lunachow.com/",
+        "address": "0xa5ef74068d04ba0809b7379dd76af5ce34ab7c57",
+        "bridgeContract": "https://etherscan.io/address/0x3ee18B2214AFF97000D974cf647E7C347E8fa585",
+        "assetContract": "https://etherscan.io/address/0xa5ef74068d04ba0809b7379dd76af5ce34ab7c57",
+        "coingeckoId": "lunachow",
+        "reddit": "https://www.reddit.com/r/lunachow/",
+        "twitter": "https://twitter.com/LunaChoww",
+        "discord": "https://discord.gg/FBz7dGkxgv",
+        "facebook": "https://www.facebook.com/LunaChowOfficial",
+        "instagram": "https://www.instagram.com/lunachow.io/",
+        "telegram": "https://t.me/LuChow"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "9k27FY1wmxKEyoMGqK4zJMT2Y8dvkiYRGM2ijjLLTrjq",
+      "symbol": "UNIVERSE",
+      "name": "universe",
+      "decimals": 8,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/9k27FY1wmxKEyoMGqK4zJMT2Y8dvkiYRGM2ijjLLTrjq/logo.png",
+      "tags": [
+        "Metaverse",
+        "Universe"
+      ],
+      "extensions": {
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "CA3XWNSEQNtBiiWQE9CQJp5G93eAZKZF7j6wx9tMTZR7",
+      "symbol": "CHEEZ",
+      "name": "Cheezburger",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/CA3XWNSEQNtBiiWQE9CQJp5G93eAZKZF7j6wx9tMTZR7/logo.png",
+      "tags": [
+        "social-token",
+        "meme-token"
+      ],
+      "extensions": {
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "6kr8q1SXXNRLy3imzDsecWkcRtzJiXqiXx1N7LtpMPTe",
+      "symbol": "BIT",
+      "name": "Biconomy Token",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/6kr8q1SXXNRLy3imzDsecWkcRtzJiXqiXx1N7LtpMPTe/logo.png",
+      "tags": [
+        "exchange-token"
+      ],
+      "extensions": {
+        "bridgeContract": "https://bscscan.com/token/0xc864019047B864B6ab609a968ae2725DFaee808A",
+        "website": "https://biconomy.com",
+        "coingeckoId": "biconomy-exchange-token"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "EFBGjiTEuvhwZGmEzDBJwrWnSDuALx94MERncXNsap3G",
+      "symbol": "RBTP",
+      "name": "Robotopian Token",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/EFBGjiTEuvhwZGmEzDBJwrWnSDuALx94MERncXNsap3G/logo.png",
+      "tags": [
+        "utility-token"
+      ],
+      "extensions": {
+        "website": "https://robotopia.io"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "7tfCwa3CCNzhvLCkKPaBWvYxyjq157Wha1EDKZJAxBZ",
+      "symbol": "RBTK",
+      "name": "Robotopian Token",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/7tfCwa3CCNzhvLCkKPaBWvYxyjq157Wha1EDKZJAxBZ/logo.png",
+      "tags": [
+        "utility-token"
+      ],
+      "extensions": {
+        "website": "https://robotopia.io"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "Dm3qVmVLAEQPSHoHCzAuF1gpmT2k2SXe1Pw2FgtUVAaC",
+      "symbol": "DNG",
+      "name": "DNG Reasearch Token",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/Dm3qVmVLAEQPSHoHCzAuF1gpmT2k2SXe1Pw2FgtUVAaC/logo.png",
+      "tags": [
+        "social-token"
+      ],
+      "extensions": {
+        "website": "http://d-n-g.io/"
+      }
+    },
+    {
       "chainId": 101,
       "address": "HiQg2CX9BU24gsgDVXg5DR437z5ptYvnT3KY1D7nqfAw",
       "symbol": "ORD",
@@ -23018,95 +23088,101 @@
         "website": "https://oridion.io",
         "twitter": "https://twitter.com/OridionToken"
       }
-    }
-,{
+    },
+    {
       "chainId": 101,
       "address": "3mXx1bNiB5bhgwznk4eeqM9eoy6DU3CeCkm1LPabeoEh",
       "symbol": "SAMOY",
       "name": "Samoy Meme Dog",
       "decimals": 9,
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/3mXx1bNiB5bhgwznk4eeqM9eoy6DU3CeCkm1LPabeoEh/logo.png",
-      "tags": [ "Meme-Token" ,"Community-Token"],
+      "tags": [
+        "Meme-Token",
+        "Community-Token"
+      ],
       "extensions": {}
-    }
-	,{
-  "chainId": 101,
-  "address": "5pGUEKhMLa7VCvGeP1acgGKPe2vpzQF5hhpyQAFsH2Cg",
-  "symbol": "COSP",
-  "name": "Cosplay Coin",
-  "decimals": 9,
-  "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/5pGUEKhMLa7VCvGeP1acgGKPe2vpzQF5hhpyQAFsH2Cg/logo.png",
-  "tags": [
-    "social-token",
-    "utility-token",
-    "nft"
-  ],
-  "extensions": {
-    "website": "https://cosplaycoin.xyz",
-    "twitter": "https://twitter.com/CosplayCoin"
-  }
-}, {
-  "chainId": 101,
-  "address": "B6nUf6nNex5Eh41xU6NY4qu9xNwyFyDFxKbRjdkPPenT",
-  "symbol": "DIGART",
-  "name": "Digital Artists Coin",
-  "decimals": 9,
-  "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/B6nUf6nNex5Eh41xU6NY4qu9xNwyFyDFxKbRjdkPPenT/logo.png",
-  "tags": [
-    "social-token",
-    "utility-token",
-    "nft"
-  ],
-  "extensions": {
-    "website": "https://digartcoin.xyz",
-    "twitter": "https://twitter.com/digartcoin"
-  }
-},
- {
-  "chainId": 101,
-  "address": "9aj5LDmjjwBXk5ijfoyQej3X6waV1rnk7QN4KVqjX8wH",
-  "symbol": "ARS",
-  "name": "Artists Coin",
-  "decimals": 9,
-  "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/9aj5LDmjjwBXk5ijfoyQej3X6waV1rnk7QN4KVqjX8wH/logo.png",
-  "tags": [
-    "social-token",
-    "utility-token",
-    "nft"
-  ],
-  "extensions": {
-    "website": "https://artistscoin.xyz",
-    "twitter": "https://twitter.com/artistscoin",
-	"instagram": "https://www.instagram.com/artistscoin"
-  }
-},{
-  "chainId": 101,
-  "address": "Dhg9XnzJWzSQqH2aAnhPTEJHGQAkALDfD98MA499A7pa",
-  "symbol": "SHIBA",
-  "name": "Shibalana",
-  "decimals": 9,
-  "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/Dhg9XnzJWzSQqH2aAnhPTEJHGQAkALDfD98MA499A7pa/logo.png",
-  "tags": [],
-  "extensions": {
-    "website": "https://shibalana.com/",
-    "twitter": "https://twitter.com/shibalana",
-    "discord": "https://discord.gg/UaK3ZMkkmH",
-    "telegram": "https://t.me/shibalana"
-  }
-}
-,{
-          "chainId": 101,
-          "address": "7TPWAzabCP26vuLGuAhBMJFSs5LQNVsw4uFyQUkSGJXj",
-          "symbol": "PORN",
-          "name": "Pornlana",
-          "decimals": 9,
-          "logoURI": "https://raw.githubusercontent.com/Agaveis/pornlana/main/logo.png",
-          "tags": ["meme-token"],
-          "extensions": {
-            "website": "http://pornlana.com"
-          }
-        }
-        ,
+    },
+    {
+      "chainId": 101,
+      "address": "5pGUEKhMLa7VCvGeP1acgGKPe2vpzQF5hhpyQAFsH2Cg",
+      "symbol": "COSP",
+      "name": "Cosplay Coin",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/5pGUEKhMLa7VCvGeP1acgGKPe2vpzQF5hhpyQAFsH2Cg/logo.png",
+      "tags": [
+        "social-token",
+        "utility-token",
+        "nft"
+      ],
+      "extensions": {
+        "website": "https://cosplaycoin.xyz",
+        "twitter": "https://twitter.com/CosplayCoin"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "B6nUf6nNex5Eh41xU6NY4qu9xNwyFyDFxKbRjdkPPenT",
+      "symbol": "DIGART",
+      "name": "Digital Artists Coin",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/B6nUf6nNex5Eh41xU6NY4qu9xNwyFyDFxKbRjdkPPenT/logo.png",
+      "tags": [
+        "social-token",
+        "utility-token",
+        "nft"
+      ],
+      "extensions": {
+        "website": "https://digartcoin.xyz",
+        "twitter": "https://twitter.com/digartcoin"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "9aj5LDmjjwBXk5ijfoyQej3X6waV1rnk7QN4KVqjX8wH",
+      "symbol": "ARS",
+      "name": "Artists Coin",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/9aj5LDmjjwBXk5ijfoyQej3X6waV1rnk7QN4KVqjX8wH/logo.png",
+      "tags": [
+        "social-token",
+        "utility-token",
+        "nft"
+      ],
+      "extensions": {
+        "website": "https://artistscoin.xyz",
+        "twitter": "https://twitter.com/artistscoin",
+        "instagram": "https://www.instagram.com/artistscoin"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "Dhg9XnzJWzSQqH2aAnhPTEJHGQAkALDfD98MA499A7pa",
+      "symbol": "SHIBA",
+      "name": "Shibalana",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/Dhg9XnzJWzSQqH2aAnhPTEJHGQAkALDfD98MA499A7pa/logo.png",
+      "tags": [],
+      "extensions": {
+        "website": "https://shibalana.com/",
+        "twitter": "https://twitter.com/shibalana",
+        "discord": "https://discord.gg/UaK3ZMkkmH",
+        "telegram": "https://t.me/shibalana"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "7TPWAzabCP26vuLGuAhBMJFSs5LQNVsw4uFyQUkSGJXj",
+      "symbol": "PORN",
+      "name": "Pornlana",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/Agaveis/pornlana/main/logo.png",
+      "tags": [
+        "meme-token"
+      ],
+      "extensions": {
+        "website": "http://pornlana.com"
+      }
+    },
     {
       "chainId": 101,
       "address": "3xVf2hPbkE5TuZNUPLQXFgFLD4LpvCM45BodbPmnpSSV",
@@ -23114,60 +23190,66 @@
       "name": "SolBull - GoPromotedToken",
       "decimals": 9,
       "logoURI": "https://static-cdn.jtvnw.net/jtv_user_pictures/3c80cc31-8f98-4a1f-83b7-c20a9babbb97-profile_image-70x70.png",
-      "tags": [ "Utility-Token" ],
+      "tags": [
+        "Utility-Token"
+      ],
       "extensions": {
         "website": "http://gopromoted.com/",
         "twitter": "https://twitter.com/GoPromotedCom"
       }
-    }
-,{
-          "chainId": 101,
-          "address":  "8gWEnKqB4qVQgC8yAorMxhiEKqsDcxZSVKFVbQ8g1fzB",
-          "symbol": "PORN",
-          "name": "Pornlana",
-          "decimals": 9,
-          "logoURI": "https://raw.githubusercontent.com/Agaveis/pornlana/main/logo.png",
-          "tags": ["meme-token"],
-          "extensions": {
-            "website": "http://pornlana.com"
-          }
-        }
-                ,
-                {
-                  "chainId": 101,
-                  "address": "UXPhBoR3qG4UCiGNJfV7MqhHyFqKN68g45GoYvAeL2M",
-                  "symbol": "UXP",
-                  "name": "UXP Governance Token",
-                  "decimals": 9,
-                  "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/UXPhBoR3qG4UCiGNJfV7MqhHyFqKN68g45GoYvAeL2M/logo.png",
-                  "tags": [
-                    "UXD",
-                    "UXP",
-                    "governance",
-                    "DAO",
-                    "stablecoin",
-                    "Web 3.0"
-                  ],
-                  "extensions": {
-                    "website": "https://uxd.fi/",
-                    "twitter": "https://twitter.com/UXDProtocol",
-                    "medium": "https://uxdprotocol.medium.com/",
-                    "discord": "https://discord.com/invite/BHfpYmjsBM"
-                  }
-                }
-	,{
+    },
+    {
+      "chainId": 101,
+      "address": "8gWEnKqB4qVQgC8yAorMxhiEKqsDcxZSVKFVbQ8g1fzB",
+      "symbol": "PORN",
+      "name": "Pornlana",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/Agaveis/pornlana/main/logo.png",
+      "tags": [
+        "meme-token"
+      ],
+      "extensions": {
+        "website": "http://pornlana.com"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "UXPhBoR3qG4UCiGNJfV7MqhHyFqKN68g45GoYvAeL2M",
+      "symbol": "UXP",
+      "name": "UXP Governance Token",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/UXPhBoR3qG4UCiGNJfV7MqhHyFqKN68g45GoYvAeL2M/logo.png",
+      "tags": [
+        "UXD",
+        "UXP",
+        "governance",
+        "DAO",
+        "stablecoin",
+        "Web 3.0"
+      ],
+      "extensions": {
+        "website": "https://uxd.fi/",
+        "twitter": "https://twitter.com/UXDProtocol",
+        "medium": "https://uxdprotocol.medium.com/",
+        "discord": "https://discord.com/invite/BHfpYmjsBM"
+      }
+    },
+    {
       "chainId": 101,
       "address": "88govxpekHhHv4hF2bgi8UDveP9LnxofhdREmrxLffy8",
       "symbol": "USTK",
       "name": "Ultra Scarce Token",
       "decimals": 9,
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/88govxpekHhHv4hF2bgi8UDveP9LnxofhdREmrxLffy8/logo.png",
-      "tags": ["utility-token", "wrapped"],
+      "tags": [
+        "utility-token",
+        "wrapped"
+      ],
       "extensions": {
-        "website": ""        
+        "website": ""
       }
-    }
-    ,{
+    },
+    {
       "chainId": 101,
       "address": "2uEb2S4JCxZSzMxRfEdmj6grtZkgEe6XrfTwgkpswuvS",
       "symbol": "VAL",
@@ -23175,107 +23257,113 @@
       "decimals": 9,
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/2uEb2S4JCxZSzMxRfEdmj6grtZkgEe6XrfTwgkpswuvS/Valknut.png",
       "tags": [
-        "nft","game-coin","gaming","Blockchain Game"
+        "nft",
+        "game-coin",
+        "gaming",
+        "Blockchain Game"
       ],
       "extensions": {
         "website": "https://solvikings.com/",
-        "discord":"https://discord.com/invite/JXKEDfYGGa",
-        "twitter":"https://twitter.com/solvikingsnft"
+        "discord": "https://discord.com/invite/JXKEDfYGGa",
+        "twitter": "https://twitter.com/solvikingsnft"
       }
-    }
-	,{
-          "chainId": 101,
-          "address": "E6Hkw5o48QfNo6iUi1aepjEBzVq4ZjQLxh7xVtdTqoyB",
-          "symbol": "DICK",
-          "name": "Dickcoin",
-          "decimals": 9,
-          "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/E6Hkw5o48QfNo6iUi1aepjEBzVq4ZjQLxh7xVtdTqoyB/logo.png",
-          "tags": ["utility-token"],
-          "extensions": {
-            "twitter": "https://twitter.com/dickcoinmoon"
-          }
-        }
-		,{
+    },
+    {
+      "chainId": 101,
+      "address": "E6Hkw5o48QfNo6iUi1aepjEBzVq4ZjQLxh7xVtdTqoyB",
+      "symbol": "DICK",
+      "name": "Dickcoin",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/E6Hkw5o48QfNo6iUi1aepjEBzVq4ZjQLxh7xVtdTqoyB/logo.png",
+      "tags": [
+        "utility-token"
+      ],
+      "extensions": {
+        "twitter": "https://twitter.com/dickcoinmoon"
+      }
+    },
+    {
       "chainId": 101,
       "address": "3uXMgtaMRBcyEtEChgiLMdHDjb5Azr17SQWwQo3ppEH8",
       "symbol": "WBRZ",
-    "name": "Wrapped BRZ",
+      "name": "Wrapped BRZ",
       "decimals": 6,
       "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x420412E765BFa6d85aaaC94b4f7b708C89be2e2B/logo.png",
-      "tags": ["exchange-token"],
+      "tags": [
+        "exchange-token"
+      ],
       "extensions": {
-	    "website":"https://www.brztoken.io/"
+        "website": "https://www.brztoken.io/"
       }
-}
-	,{
-    "chainId": 101,
-    "address": "AvB7Ffmt3H16bhq7ToXb839ynKzFgJxu2WDHsR1S9Yft",
-    "symbol": "FLOKIS",
-    "name": "FlokiSol",
-    "decimals": 4,
-    "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/AvB7Ffmt3H16bhq7ToXb839ynKzFgJxu2WDHsR1S9Yft/Flokisol.png",
-    "tags": [
-    "community-token", "meme-token"
-    ],
-    "extensions": {
-      "twitter": "https://twitter.com/FlokiSol",
-      "website": "https://flokisol.com"
-    }
-}
-,
-{
-  "chainId": 101,
-  "address": "TrickCA8nD77Y6iHHEQBAaBFDjFa5zohSThmSVfz2X9",
-  "symbol": "Trick",
-  "name": "SolTricks token",
-  "decimals": 9,
-  "logoURI": "http://static.soltricks.io/icon.png",
-  "tags": [
-    "utility-token"
-  ],
-  "extensions": {
-    "website": "https://soltricks.io",
-    "discord ": "https://discord.soltricks.io",
-    "twitter ": "https://twitter.com/soltricks"
-
-  }}
-  ,
-{
-  "chainId": 101,
-  "address": "rendopHqu4oE94AXjEEtporr1xW8Fsp4bZDccyMTYzU",
-  "symbol": "RENDO",
-  "name": "rendo.club",
-  "decimals": 9,
-  "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/rendopHqu4oE94AXjEEtporr1xW8Fsp4bZDccyMTYzU/logo.png",
-  "tags": [
-    "utility-token"
-  ],
-  "extensions": {
-    "website": "https://rendo.club",
-    "discord ": "https://discord.gg/SvNZZu6",
-    "twitter ": "https://twitter.com/rendo"
-
-  }}
-  ,{
-  "chainId": 101,
-  "address": "F7mgxaYF1gg1hBtaVzENSG6ey3pn6J1mXhBRmHxDzBNg ",
-  "address": "F7mgxaYF1gg1hBtaVzENSG6ey3pn6J1mXhBRmHxDzBNg",
-  "symbol": "SINU ",
-  "symbol": "SINU",
-  "name": "Samo INU ",
-  "name": "Samo INU",
-  "decimals": 9,
-  "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/F7mgxaYF1gg1hBtaVzENSG6ey3pn6J1mXhBRmHxDzBNg/logo.png",
-  "tags": [
-    "meme-token"
-  ],
-  "extensions": {
-    "website": "https://www.samoinu.com",
-    "discord":"http://discord.gg/samoinu",
-    "twitter":"https://twitter.com/samo_inu"
-  }
-}
-    ,{
+    },
+    {
+      "chainId": 101,
+      "address": "AvB7Ffmt3H16bhq7ToXb839ynKzFgJxu2WDHsR1S9Yft",
+      "symbol": "FLOKIS",
+      "name": "FlokiSol",
+      "decimals": 4,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/AvB7Ffmt3H16bhq7ToXb839ynKzFgJxu2WDHsR1S9Yft/Flokisol.png",
+      "tags": [
+        "community-token",
+        "meme-token"
+      ],
+      "extensions": {
+        "twitter": "https://twitter.com/FlokiSol",
+        "website": "https://flokisol.com"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "TrickCA8nD77Y6iHHEQBAaBFDjFa5zohSThmSVfz2X9",
+      "symbol": "Trick",
+      "name": "SolTricks token",
+      "decimals": 9,
+      "logoURI": "http://static.soltricks.io/icon.png",
+      "tags": [
+        "utility-token"
+      ],
+      "extensions": {
+        "website": "https://soltricks.io",
+        "discord ": "https://discord.soltricks.io",
+        "twitter ": "https://twitter.com/soltricks"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "rendopHqu4oE94AXjEEtporr1xW8Fsp4bZDccyMTYzU",
+      "symbol": "RENDO",
+      "name": "rendo.club",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/rendopHqu4oE94AXjEEtporr1xW8Fsp4bZDccyMTYzU/logo.png",
+      "tags": [
+        "utility-token"
+      ],
+      "extensions": {
+        "website": "https://rendo.club",
+        "discord ": "https://discord.gg/SvNZZu6",
+        "twitter ": "https://twitter.com/rendo"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "F7mgxaYF1gg1hBtaVzENSG6ey3pn6J1mXhBRmHxDzBNg ",
+      "address": "F7mgxaYF1gg1hBtaVzENSG6ey3pn6J1mXhBRmHxDzBNg",
+      "symbol": "SINU ",
+      "symbol": "SINU",
+      "name": "Samo INU ",
+      "name": "Samo INU",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/F7mgxaYF1gg1hBtaVzENSG6ey3pn6J1mXhBRmHxDzBNg/logo.png",
+      "tags": [
+        "meme-token"
+      ],
+      "extensions": {
+        "website": "https://www.samoinu.com",
+        "discord": "http://discord.gg/samoinu",
+        "twitter": "https://twitter.com/samo_inu"
+      }
+    },
+    {
       "chainId": 101,
       "address": "4BPw4jwHWqQCbkD2VWtLFL5PLBRmkHZiievTm1ebiWYJ",
       "symbol": "NPC",
@@ -23292,466 +23380,506 @@
         "twitter": "https://twitter.com/NoleNPC",
         "telegram": "https://t.me/NoleNPC"
       }
-    }
-,{"chainId":101,"address":"Ac7GiHwC7vZU2y97GRh9rqCqqnKAAgopYrTAtKccHxUk","symbol":"SINU","name":"Samo INU","decimals":9,"logoURI":"https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/Ac7GiHwC7vZU2y97GRh9rqCqqnKAAgopYrTAtKccHxUk/logo.png","tags":["meme-token","community-token"],"extensions":{"website":"https://www.samoinu.com","discord":"http://discord.gg/samoinu","twitter":"https://twitter.com/samo_inu","description":"Samo Inu is an hybrid meme coin with fun and social utilities"}}
-,{
-  "chainId": 101,
-  "address": "2LxZrcJJhzcAju1FBHuGvw929EVkX7R7Q8yA2cdp8q7b ",
-  "address": "2LxZrcJJhzcAju1FBHuGvw929EVkX7R7Q8yA2cdp8q7b",
-  "symbol": "BORK",
-  "name": "BORK",
-  "decimals": 3,
-  "logoURI": "https://arweave.net/VtJL5kdepu6AyVHnHi4GImgyWxmcb2XMPN7jURW_yXQ",
-  "tags": [
-    "meme-token"
-  ],
-  "extensions": {
-    "website": "https://www.borksolana.club",
-    "discord":"https://discord.gg/fazKMkWSSA",
-    "twitter":"https://twitter.com/borksolana"
-  }
-}
- ,{"chainId": 101, "address":  "53dqN1unCex98QWzLZtk1ssJptEcRwZapTrv8pakcgNB", "symbol":  "LGBR", "name": "LGBR - LETS GO BRANDON", "decimals": 9, "logoURI": "http://gopromoted.com/brandon.jpg", "tags": ["Meme-coin"], "extensions": { "discord":  "https://discord.gg/Qb7QRNAeH2", "twitter":  "https://twitter.com/LGBRCoin", "whitepaper":  "https://docs.google.com/document/d/1krRMK_b2DkvgV0AEl9rKN2LU4lh-QACWi9rXByfG8tQ/edit?usp=sharing"} }
-,{
-  "chainId": 101,
-  "address": "4dzDhawz7bHfDDfBpbDrLeDu6T7vZEtmmyQtn9Df2PRa",
-  "symbol": "PUMP",
-  "name": "PUMP",
-  "decimals": 3,
-  "logoURI": "https://wtcaeyantzogvbrzbwcgqfesfnz7mekovkyybs3ae54fptigq5za.arweave.net/tMQCYA2eXGqGOQ2EaBSSK3P2EU6qsYDLYCd4V80Gh3I",
-  "tags": [
-    "meme-token"
-  ],
-  "extensions": {
-    "discord":"https://discord.gg/Tab4WFUSY2",
-    "twitter":"https://twitter.com/S0l_Pump"
-  }
-}
-,{
-  "chainId": 101,
-  "address": "5uE8w9yoMMu88NV8wUaZMuxCiufBBoSiJbNDAEGmDx7x",
-  "symbol": "SCIFI",
-  "name": "SciFi-Verse",
-  "decimals": 9,
-  "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/5uE8w9yoMMu88NV8wUaZMuxCiufBBoSiJbNDAEGmDx7x/logo.png",
-  "tags": [
-    "SciFi","Game"
-  ],
-  "extensions": {
-    "website": "https://www.scifiverse.net"
-  }
-},{
-  "chainId": 101,
-  "address": "BTSPdFLQJ9R3JXAgjVx2JtLq4sNSjiVSGh4tQi4oRUi8",
-  "symbol": "DYOR",
-  "name": "DO YOUR OWN RESEARCH",
-  "decimals": 5,
-  "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/BTSPdFLQJ9R3JXAgjVx2JtLq4sNSjiVSGh4tQi4oRUi8/logo.png",
-  "tags": [
-	"utility-token"
-  ],
-  "extensions": {
-    "website": "http://s0lnumbers.com/",
-	"discord": "https://discord.com/invite/wXaGzqUuru",
-	"twitter": "https://twitter.com/s0lnumbers"
-  }
-},
-{
-  "chainId": 101,
-  "address": "5i8C6n4VbELnTHtES83aqeh16uPiEyve4jHr2QN2WhSz",
-  "symbol": "ZDRT",
-  "name": "ZDRT Club Token",
-  "decimals": 3,
-  "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/5i8C6n4VbELnTHtES83aqeh16uPiEyve4jHr2QN2WhSz/logo.png",
-  "tags": [
-	"social-token"
-  ],
-  "extensions": {
-    "website": "https://zdrt.club",
-	"discord": "hhttps://discord.gg/VHpA4tQYXZ"
-  }
-},
-{
-  "chainId": 101,
-  "address": "4wfCtMp8KQ7r61V4qH2VtHxFjVjUdsWhgAmZgQi33UkT",
-  "symbol": "ARDN",
-  "name": "Ariadne Solana",
-  "decimals": 9,
-  "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/4wfCtMp8KQ7r61V4qH2VtHxFjVjUdsWhgAmZgQi33UkT/logo.svg",
-  "tags": [
-    "utility-token",
-    "DeFi",
-    "marketplace",
-    "ariadne"
-  ],
-  "extensions": {
-    "coingeckoId": "ariadne",
-    "website": "https://ariadne.finance/",
-    "twitter": "https://twitter.com/Ariadne_finance",
-    "medium": "https://medium.com/ariadne-project",
-    "telegram": "https://t.me/ariadne_finance"
-  }
-},
-{
-  "chainId": 101,
-  "address": "GcqEZcpnMYmxRhPp9sRh1wLLWTmFjTwp7CVQcuYX73sT",
-  "symbol": "WHALE",
-  "name": "Whale Token",
-  "decimals": 8,
-  "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/GcqEZcpnMYmxRhPp9sRh1wLLWTmFjTwp7CVQcuYX73sT/logo.png",
-  "tags": [
-    "community-token",
-    "meme-token",
-    "whale",
-    "whale-token",
-    "crypto-whale"
-  ],
-  "extensions": {
-    "twitter": "https://twitter.com/CryptoWhale",
-    "website":"https://cryptowhale.org/"
-  }
-},
-{
-  "chainId": 101,
-  "address": "5fhXkD8tXyDB9rmYZSNJ6LneLr2nMteMpCVxeDDEgXa3",
-  "symbol": "ACE",
-  "name": "ACE",
-  "decimals": 9,
-  "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/5fhXkD8tXyDB9rmYZSNJ6LneLr2nMteMpCVxeDDEgXa3/logo.png",
-  "tags": [],
-  "extensions": {
-    "website":""
-  }
-},
-{
-  "chainId": 101,
-  "address": "CJ2K2J3HYU6ibR1JwLkUmD9RM8eytfxtMcLzYPqoQQKo",
-  "symbol": "BONER",
-  "name": "BONER",
-  "decimals": 6,
-  "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/CJ2K2J3HYU6ibR1JwLkUmD9RM8eytfxtMcLzYPqoQQKo/logo.png",
-  "tags": [
-    "utility-token",
-    "nft-token"
-  ],
-  "extensions": {
-    "website": "https://www.barebonesnft.com/",
-    "twitter": "https://twitter.com/BareBonesNFT"
-  }
-},
-{
-  "chainId": 101,
-  "address": "8o66EVAf4u2Hr21m2tuRrPtEXFPLr8G8aL1ETStP8fDu",
-  "symbol": "VIBE",
-  "name": "VIBE",
-  "decimals": 4,
-  "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/8o66EVAf4u2Hr21m2tuRrPtEXFPLr8G8aL1ETStP8fDu/VIBE-logo.png",
-  "tags": [
-    "utility-token",
-    "nft-token"
-  ],
-  "extensions": {
-    "website": "https://twitter.com/vibetoken_",
-    "discord": "https://discord.gg/CQQSSSgTDb"
-  }
-},
-{
-    "chainId": 101,
-    "address": "9bPoFPCwGCVGDMC5gvzisPdjgKC6tRLRDhirJvcktgVh",
-    "symbol": "SPIRIT",
-    "name": "Spirit",
-    "decimals": 0,
-    "logoURI": "https://raw.githubusercontent.com/Yuriy-Ihor/CyberGothicaAssets/main/Token/logo.png",
-    "tags": [
-		"game-token",
-		"game-currency"
-    ],
-    "extensions": {
-		"twitter": "https://twitter.com/Cyber_Gothica"
-    }
-},
-{
-    "chainId": 101,
-    "address": "Ax9MbdUbr7cPQhkipXnBh2QNDSzf245Sn4xKfQUDuJGD",
-    "symbol": "EDGE",
-    "name": "Lord Edge Elon",
-    "decimals": 9,
-    "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/Ax9MbdUbr7cPQhkipXnBh2QNDSzf245Sn4xKfQUDuJGD/logo.png",
-    "tags": [
-      "Meme-token",
-      "DEFI",
-      "Elon",
-      "Community"
-  
-    ],
-    "extensions": {
-      "twitter":"https://twitter.com/LordedgeSol",
-      "website": "https://lordedgesol.com",
-      "Telegram":"https://t.me/lordedgesol"
-    }
-  },
-{
-  "chainId": 101,
-  "address": "Fzs17QjYy7ZicGgBv2auDGA55TEV2PfSpK8cCax9m6fh",
-  "symbol": "NBX",
-  "name": "Nathan Bolin Coin",
-  "decimals": 9,
-  "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/Fzs17QjYy7ZicGgBv2auDGA55TEV2PfSpK8cCax9m6fh/logo.png",
-  "tags": [
-    "social-token",
-    "utility-token",
-    "community-token"
-  ],
-  "extensions": {
-    "website": "http://nathanbolin.com/",
-    "twitter": "https://twitter.com/nathanbolin"
-  }
-}
-,
-{
-  "chainId": 101,
-  "address": "DYbRXaQcnj44SH9woxvyFdtcKkSoPoCEshRTQDZSjsBm",
-  "symbol": "MARIJUANA",
-  "name": "Marijuana Joint",
-  "decimals": 9,
-  "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/DYbRXaQcnj44SH9woxvyFdtcKkSoPoCEshRTQDZSjsBm/logo.png",
-  "tags": [
-    "Meme", "Social"
-  ],
-  "extensions": {
-  }
-},
-{
-  "chainId": 101,
-  "address": "FiPpi1nhxws1cPkyy76AzmHkFMyB3NysdU8RruTXuzNf",
-  "symbol": "KAJU",
-  "name": "KAJU Coin",
-  "decimals": 9,
-  "logoURI": "https://raw.githubusercontent.com/kajucoin/assets/main/logo.jpg",
-  "tags": [
-    "Meme", "Social"
-  ],
-  "extensions": {
-    "website": "http://www.kajucoin.com/",
-    "twitter": "https://twitter.com/kajucoin",
-    "instagram": "http://instagram.com/kajucoin"
-  }
-},
-{
-  "chainId": 101,
-  "address": "FCqfQSujuPxy6V42UvafBhsysWtEq1vhjfMN1PUbgaxA",
-  "symbol": "USDC",
-  "name": "USD Coin (Wormhole)",
-  "decimals": 8,
-  "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/FCqfQSujuPxy6V42UvafBhsysWtEq1vhjfMN1PUbgaxA/logo.png",
-  "tags": [
-    "wrapped"
-  ],
-  "extensions": {
-    "address": "0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d",
-    "bridgeContract": "https://bscscan.com/address/0xB6F6D86a8f9879A9c87f643768d9efc38c1Da6E7",
-    "assetContract": "https://bscscan.com/address/0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d"
-  }
-},
-{
-  "chainId": 101,
-  "address": "ASoLXbfe7cd6igh5yiEsU8M7FW64QRxPKkxk7sjAfond",
-  "symbol": "aSOL",
-  "name": "aSOL Aggregate Solana Stake Pool",
-  "decimals": 9,
-  "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/ASoLXbfe7cd6igh5yiEsU8M7FW64QRxPKkxk7sjAfond/logo.svg",
-  "tags": [],
-  "extensions": {
-    "coingeckoId": "solana",
-    "description": "aSOL is the standard for transacting with staked SOL tokens.",
-    "website": "https://asol.so",
-    "twitter": "https://twitter.com/aSOLprotocol",
-    "github": "https://github.com/aSolHQ"
-  }
-},
-{
+    },
+    {
+      "chainId": 101,
+      "address": "Ac7GiHwC7vZU2y97GRh9rqCqqnKAAgopYrTAtKccHxUk",
+      "symbol": "SINU",
+      "name": "Samo INU",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/Ac7GiHwC7vZU2y97GRh9rqCqqnKAAgopYrTAtKccHxUk/logo.png",
+      "tags": [
+        "meme-token",
+        "community-token"
+      ],
+      "extensions": {
+        "website": "https://www.samoinu.com",
+        "discord": "http://discord.gg/samoinu",
+        "twitter": "https://twitter.com/samo_inu",
+        "description": "Samo Inu is an hybrid meme coin with fun and social utilities"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "2LxZrcJJhzcAju1FBHuGvw929EVkX7R7Q8yA2cdp8q7b ",
+      "address": "2LxZrcJJhzcAju1FBHuGvw929EVkX7R7Q8yA2cdp8q7b",
+      "symbol": "BORK",
+      "name": "BORK",
+      "decimals": 3,
+      "logoURI": "https://arweave.net/VtJL5kdepu6AyVHnHi4GImgyWxmcb2XMPN7jURW_yXQ",
+      "tags": [
+        "meme-token"
+      ],
+      "extensions": {
+        "website": "https://www.borksolana.club",
+        "discord": "https://discord.gg/fazKMkWSSA",
+        "twitter": "https://twitter.com/borksolana"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "53dqN1unCex98QWzLZtk1ssJptEcRwZapTrv8pakcgNB",
+      "symbol": "LGBR",
+      "name": "LGBR - LETS GO BRANDON",
+      "decimals": 9,
+      "logoURI": "http://gopromoted.com/brandon.jpg",
+      "tags": [
+        "Meme-coin"
+      ],
+      "extensions": {
+        "discord": "https://discord.gg/Qb7QRNAeH2",
+        "twitter": "https://twitter.com/LGBRCoin",
+        "whitepaper": "https://docs.google.com/document/d/1krRMK_b2DkvgV0AEl9rKN2LU4lh-QACWi9rXByfG8tQ/edit?usp=sharing"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "4dzDhawz7bHfDDfBpbDrLeDu6T7vZEtmmyQtn9Df2PRa",
+      "symbol": "PUMP",
+      "name": "PUMP",
+      "decimals": 3,
+      "logoURI": "https://wtcaeyantzogvbrzbwcgqfesfnz7mekovkyybs3ae54fptigq5za.arweave.net/tMQCYA2eXGqGOQ2EaBSSK3P2EU6qsYDLYCd4V80Gh3I",
+      "tags": [
+        "meme-token"
+      ],
+      "extensions": {
+        "discord": "https://discord.gg/Tab4WFUSY2",
+        "twitter": "https://twitter.com/S0l_Pump"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "5uE8w9yoMMu88NV8wUaZMuxCiufBBoSiJbNDAEGmDx7x",
+      "symbol": "SCIFI",
+      "name": "SciFi-Verse",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/5uE8w9yoMMu88NV8wUaZMuxCiufBBoSiJbNDAEGmDx7x/logo.png",
+      "tags": [
+        "SciFi",
+        "Game"
+      ],
+      "extensions": {
+        "website": "https://www.scifiverse.net"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "BTSPdFLQJ9R3JXAgjVx2JtLq4sNSjiVSGh4tQi4oRUi8",
+      "symbol": "DYOR",
+      "name": "DO YOUR OWN RESEARCH",
+      "decimals": 5,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/BTSPdFLQJ9R3JXAgjVx2JtLq4sNSjiVSGh4tQi4oRUi8/logo.png",
+      "tags": [
+        "utility-token"
+      ],
+      "extensions": {
+        "website": "http://s0lnumbers.com/",
+        "discord": "https://discord.com/invite/wXaGzqUuru",
+        "twitter": "https://twitter.com/s0lnumbers"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "5i8C6n4VbELnTHtES83aqeh16uPiEyve4jHr2QN2WhSz",
+      "symbol": "ZDRT",
+      "name": "ZDRT Club Token",
+      "decimals": 3,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/5i8C6n4VbELnTHtES83aqeh16uPiEyve4jHr2QN2WhSz/logo.png",
+      "tags": [
+        "social-token"
+      ],
+      "extensions": {
+        "website": "https://zdrt.club",
+        "discord": "hhttps://discord.gg/VHpA4tQYXZ"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "4wfCtMp8KQ7r61V4qH2VtHxFjVjUdsWhgAmZgQi33UkT",
+      "symbol": "ARDN",
+      "name": "Ariadne Solana",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/4wfCtMp8KQ7r61V4qH2VtHxFjVjUdsWhgAmZgQi33UkT/logo.svg",
+      "tags": [
+        "utility-token",
+        "DeFi",
+        "marketplace",
+        "ariadne"
+      ],
+      "extensions": {
+        "coingeckoId": "ariadne",
+        "website": "https://ariadne.finance/",
+        "twitter": "https://twitter.com/Ariadne_finance",
+        "medium": "https://medium.com/ariadne-project",
+        "telegram": "https://t.me/ariadne_finance"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "GcqEZcpnMYmxRhPp9sRh1wLLWTmFjTwp7CVQcuYX73sT",
+      "symbol": "WHALE",
+      "name": "Whale Token",
+      "decimals": 8,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/GcqEZcpnMYmxRhPp9sRh1wLLWTmFjTwp7CVQcuYX73sT/logo.png",
+      "tags": [
+        "community-token",
+        "meme-token",
+        "whale",
+        "whale-token",
+        "crypto-whale"
+      ],
+      "extensions": {
+        "twitter": "https://twitter.com/CryptoWhale",
+        "website": "https://cryptowhale.org/"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "5fhXkD8tXyDB9rmYZSNJ6LneLr2nMteMpCVxeDDEgXa3",
+      "symbol": "ACE",
+      "name": "ACE",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/5fhXkD8tXyDB9rmYZSNJ6LneLr2nMteMpCVxeDDEgXa3/logo.png",
+      "tags": [],
+      "extensions": {
+        "website": ""
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "CJ2K2J3HYU6ibR1JwLkUmD9RM8eytfxtMcLzYPqoQQKo",
+      "symbol": "BONER",
+      "name": "BONER",
+      "decimals": 6,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/CJ2K2J3HYU6ibR1JwLkUmD9RM8eytfxtMcLzYPqoQQKo/logo.png",
+      "tags": [
+        "utility-token",
+        "nft-token"
+      ],
+      "extensions": {
+        "website": "https://www.barebonesnft.com/",
+        "twitter": "https://twitter.com/BareBonesNFT"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "8o66EVAf4u2Hr21m2tuRrPtEXFPLr8G8aL1ETStP8fDu",
+      "symbol": "VIBE",
+      "name": "VIBE",
+      "decimals": 4,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/8o66EVAf4u2Hr21m2tuRrPtEXFPLr8G8aL1ETStP8fDu/VIBE-logo.png",
+      "tags": [
+        "utility-token",
+        "nft-token"
+      ],
+      "extensions": {
+        "website": "https://twitter.com/vibetoken_",
+        "discord": "https://discord.gg/CQQSSSgTDb"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "9bPoFPCwGCVGDMC5gvzisPdjgKC6tRLRDhirJvcktgVh",
+      "symbol": "SPIRIT",
+      "name": "Spirit",
+      "decimals": 0,
+      "logoURI": "https://raw.githubusercontent.com/Yuriy-Ihor/CyberGothicaAssets/main/Token/logo.png",
+      "tags": [
+        "game-token",
+        "game-currency"
+      ],
+      "extensions": {
+        "twitter": "https://twitter.com/Cyber_Gothica"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "Ax9MbdUbr7cPQhkipXnBh2QNDSzf245Sn4xKfQUDuJGD",
+      "symbol": "EDGE",
+      "name": "Lord Edge Elon",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/Ax9MbdUbr7cPQhkipXnBh2QNDSzf245Sn4xKfQUDuJGD/logo.png",
+      "tags": [
+        "Meme-token",
+        "DEFI",
+        "Elon",
+        "Community"
+      ],
+      "extensions": {
+        "twitter": "https://twitter.com/LordedgeSol",
+        "website": "https://lordedgesol.com",
+        "Telegram": "https://t.me/lordedgesol"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "Fzs17QjYy7ZicGgBv2auDGA55TEV2PfSpK8cCax9m6fh",
+      "symbol": "NBX",
+      "name": "Nathan Bolin Coin",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/Fzs17QjYy7ZicGgBv2auDGA55TEV2PfSpK8cCax9m6fh/logo.png",
+      "tags": [
+        "social-token",
+        "utility-token",
+        "community-token"
+      ],
+      "extensions": {
+        "website": "http://nathanbolin.com/",
+        "twitter": "https://twitter.com/nathanbolin"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "DYbRXaQcnj44SH9woxvyFdtcKkSoPoCEshRTQDZSjsBm",
+      "symbol": "MARIJUANA",
+      "name": "Marijuana Joint",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/DYbRXaQcnj44SH9woxvyFdtcKkSoPoCEshRTQDZSjsBm/logo.png",
+      "tags": [
+        "Meme",
+        "Social"
+      ],
+      "extensions": {
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "FiPpi1nhxws1cPkyy76AzmHkFMyB3NysdU8RruTXuzNf",
+      "symbol": "KAJU",
+      "name": "KAJU Coin",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/kajucoin/assets/main/logo.jpg",
+      "tags": [
+        "Meme",
+        "Social"
+      ],
+      "extensions": {
+        "website": "http://www.kajucoin.com/",
+        "twitter": "https://twitter.com/kajucoin",
+        "instagram": "http://instagram.com/kajucoin"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "FCqfQSujuPxy6V42UvafBhsysWtEq1vhjfMN1PUbgaxA",
+      "symbol": "USDC",
+      "name": "USD Coin (Wormhole)",
+      "decimals": 8,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/FCqfQSujuPxy6V42UvafBhsysWtEq1vhjfMN1PUbgaxA/logo.png",
+      "tags": [
+        "wrapped"
+      ],
+      "extensions": {
+        "address": "0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d",
+        "bridgeContract": "https://bscscan.com/address/0xB6F6D86a8f9879A9c87f643768d9efc38c1Da6E7",
+        "assetContract": "https://bscscan.com/address/0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "ASoLXbfe7cd6igh5yiEsU8M7FW64QRxPKkxk7sjAfond",
+      "symbol": "aSOL",
+      "name": "aSOL Aggregate Solana Stake Pool",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/ASoLXbfe7cd6igh5yiEsU8M7FW64QRxPKkxk7sjAfond/logo.svg",
+      "tags": [],
+      "extensions": {
+        "coingeckoId": "solana",
+        "description": "aSOL is the standard for transacting with staked SOL tokens.",
+        "website": "https://asol.so",
+        "twitter": "https://twitter.com/aSOLprotocol",
+        "github": "https://github.com/aSolHQ"
+      }
+    },
+    {
       "chainId": 101,
       "address": "Ew2xovnfCPoUwPeqtRJrk3ST8o6txNFPL2QxrcZrbspv",
       "symbol": "AUV",
       "name": "Atlantis Universe",
       "decimals": 9,
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/Ew2xovnfCPoUwPeqtRJrk3ST8o6txNFPL2QxrcZrbspv/logo.png",
-      "tags": ["games-token"],
+      "tags": [
+        "games-token"
+      ],
       "extensions": {
-       	"twitter": "https://twitter.com/atlantisvers"
-
+        "twitter": "https://twitter.com/atlantisvers"
       }
     },
-{
-  "chainId": 101,
-  "address": "8qJSyQprMC57TWKaYEmetUR3UUiTP2M3hXdcvFhkZdmv",
-  "symbol": "USDT",
-  "name": "Tether USD (Wormhole)",
-  "decimals": 8,
-  "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/8qJSyQprMC57TWKaYEmetUR3UUiTP2M3hXdcvFhkZdmv/logo.png",
-  "tags": [
-    "wrapped"
-  ],
-  "extensions": {
-    "address": "0x55d398326f99059ff775485246999027b3197955",
-    "bridgeContract": "https://bscscan.com/address/0xB6F6D86a8f9879A9c87f643768d9efc38c1Da6E7",
-    "assetContract": "https://bscscan.com/address/0x55d398326f99059ff775485246999027b3197955"
-  }
-},
-{
-"chainId": 101,
-"address": "BQTN97PwrQGkbNepQxjvcYfRPYbPNgd5PqoioYwBt4qX",
-"symbol": "ASGARD",
-"name": "Asgard Army DAO Token",
-"decimals": 9,
-"logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/BQTN97PwrQGkbNepQxjvcYfRPYbPNgd5PqoioYwBt4qX/logo.png",
-"tags": [
-  "DOA",
-  "Asgard Army",
-  "nft"
-],
-"extensions": {
-  "website": "https://asgardarmy.com/"
-}
-},
-{
-  "chainId": 101,
-  "address": "DogscQVvNVj7ndEnhWiCXPVPKKwNy9fJd4ATF7mVi5J",
-  "symbol": "DSC",
-  "name": "DoggyStyle Coin",
-  "decimals": 9,
-  "logoURI": "https://raw.githubusercontent.com/Doggystylecoin/DSC/main/logo.png",
-  "tags": [
-    "meme-token"
-  ],
-  "extensions": {
-    "twitter":"https://twitter.com/dscoinsolana"
-  }
-},
-{
-  "chainId": 101,
-  "address": "9i5WvFTCpt16Zv1Kk7mE5m9hqZ1zAoaVQwB76gcFhqLv",
-  "symbol": "SENDIT",
-  "name": "Sendit",
-  "decimals": 0,
-  "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/9i5WvFTCpt16Zv1Kk7mE5m9hqZ1zAoaVQwB76gcFhqLv/logo.png",
-  "tags": [
-    "social-token",
-    "utility-token"
-  ],
-  "extensions": {
-    "website": "https://get.stokedtosendit.com"
-  }
-},
-{
-  "chainId": 101,
-  "address": "HNpdP2rL6FR6jM3bDxFX2Zo32D1YG2ZCztf9zzCrKMEX",
-  "symbol": "SER",
-  "name": "Secretum",
-  "decimals": 8,
-  "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/HNpdP2rL6FR6jM3bDxFX2Zo32D1YG2ZCztf9zzCrKMEX/logo.svg",
-  "tags": [],
-  "extensions": {
-    "website": "https://secretum.io/",
-    "twitter": "https://twitter.com/appsecretum",
-    "telegram": "https://t.me/joinchat/ZTXM0J9pOMozOGY0"
-  }
-}
-,
-{
-  "chainId": 101,
-  "address": "3NcCuwvTMnnf7TU2UEVhp6v2nzbLXQiDgzQySS6m8A7P",
-  "symbol": "SQUIDGAME",
-  "name": "Squid Game",
-  "decimals": 9,
-  "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/3NcCuwvTMnnf7TU2UEVhp6v2nzbLXQiDgzQySS6m8A7P/logo.png",
-  "tags": [
-    "Meme","community"
-  ],
-  "extensions": {
-    
-  }
-},
-{
-  "chainId": 101,
-  "address": "7S5QMfpwnai8nF8RmHnwfGDQwGa2TURDvkHXH17tMjdn",
-  "symbol": "betaFANT",
-  "name": "betaFANT",
-  "decimals": 6,
-  "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/7S5QMfpwnai8nF8RmHnwfGDQwGa2TURDvkHXH17tMjdn/logo.png",
-  "tags": [
-    "dumby-token"
-  ],
-  "extensions": {
-    "website": "https://phantasia.app/",
-    "twitter": "https://twitter.com/PhantasiaSports",
-    "email": "phantasia@phantasia.digital",
-    "discord": "https://t.co/Vskz9PkBBC?amp=1"
-  }
-}
-,
-{
-  "chainId": 101,
-  "address": "ArhMyF2N8XpaujYUxTTDt9EuaBCaGaccxfwaZmkm9XeF",
-  "symbol": "DOGETH",
-  "name": "Doge Thug",
-  "decimals": 9,
-  "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/ArhMyF2N8XpaujYUxTTDt9EuaBCaGaccxfwaZmkm9XeF/logo.png",
-  "tags": [
-    "Meme", "Social","Metaverse"
-  ],
-  "extensions": {
-"website": "https://dogethug.samoymeme.com",
-"serumV3Usdc":"F1jBaKCMrxZpEgn79uduxpF2qHeqwiTQ3BwKdT6yqckd"
-  }
-},
-{
-  "chainId": 101,
-  "address": "D8Fc2HLd9L9V2mJnEUpnys6muJUawKYFnJWcUiaGKnyP",
-  "symbol": "OOAH",
-  "name": "OOAH Monkey",
-  "decimals": 9,
-  "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/D8Fc2HLd9L9V2mJnEUpnys6muJUawKYFnJWcUiaGKnyP/logo.png",
-  "tags": [
-    "Meme", "Social","Metaverse"
-  ],
-  "extensions": {
-"website": "https://ooah.samoymeme.com",
-"serumV3Usdc":"J6ih6rFbwkx7bMRZYjaFzkAUcsLrCMxZ9CCEbtyEAJbS"
-  }
-},
-{
-  "chainId": 101,
-  "address": "BjTUmZjNUUAPKHVdTs8yZsCmecW5isSK4AbuFihXoUwa",
-  "symbol": "PUSSY",
-  "name": "Pussy",
-  "decimals": 9,
-  "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/BjTUmZjNUUAPKHVdTs8yZsCmecW5isSK4AbuFihXoUwa/logo.png",
-  "tags": [
-    "Meme", "Social","Metaverse"
-  ],
-  "extensions": {
-"website": "https://pussy.samoymeme.com",
-"serumV3Usdc":"ALgq4dHm4bypcsg1JRDc6VPurwDtUsdsbpYB8kDxyZ9o"
-  }
-}
-,
-{
-  "chainId": 101,
-  "address": "5xq71UHmPSZ5s68DkXL8wrBVsWCh4zXgcn4wTWkqFdxa",
-  "symbol": "JESUS",
-  "name": "JESUS",
-  "decimals": 9,
-  "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/5xq71UHmPSZ5s68DkXL8wrBVsWCh4zXgcn4wTWkqFdxa/logo.png",
-  "tags": [
-    "Meme", "Social","Community"
-  ],
-  "extensions": {
-"website": "https://jesus.samoymeme.com",
-"serumV3Usdc":"7h3Pda8GwRg83NifksuZNx9xBS6voe1DyxGrQb6JqfB7"
-  }
-},
-{
+    {
+      "chainId": 101,
+      "address": "8qJSyQprMC57TWKaYEmetUR3UUiTP2M3hXdcvFhkZdmv",
+      "symbol": "USDT",
+      "name": "Tether USD (Wormhole)",
+      "decimals": 8,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/8qJSyQprMC57TWKaYEmetUR3UUiTP2M3hXdcvFhkZdmv/logo.png",
+      "tags": [
+        "wrapped"
+      ],
+      "extensions": {
+        "address": "0x55d398326f99059ff775485246999027b3197955",
+        "bridgeContract": "https://bscscan.com/address/0xB6F6D86a8f9879A9c87f643768d9efc38c1Da6E7",
+        "assetContract": "https://bscscan.com/address/0x55d398326f99059ff775485246999027b3197955"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "BQTN97PwrQGkbNepQxjvcYfRPYbPNgd5PqoioYwBt4qX",
+      "symbol": "ASGARD",
+      "name": "Asgard Army DAO Token",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/BQTN97PwrQGkbNepQxjvcYfRPYbPNgd5PqoioYwBt4qX/logo.png",
+      "tags": [
+        "DOA",
+        "Asgard Army",
+        "nft"
+      ],
+      "extensions": {
+        "website": "https://asgardarmy.com/"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "DogscQVvNVj7ndEnhWiCXPVPKKwNy9fJd4ATF7mVi5J",
+      "symbol": "DSC",
+      "name": "DoggyStyle Coin",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/Doggystylecoin/DSC/main/logo.png",
+      "tags": [
+        "meme-token"
+      ],
+      "extensions": {
+        "twitter": "https://twitter.com/dscoinsolana"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "9i5WvFTCpt16Zv1Kk7mE5m9hqZ1zAoaVQwB76gcFhqLv",
+      "symbol": "SENDIT",
+      "name": "Sendit",
+      "decimals": 0,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/9i5WvFTCpt16Zv1Kk7mE5m9hqZ1zAoaVQwB76gcFhqLv/logo.png",
+      "tags": [
+        "social-token",
+        "utility-token"
+      ],
+      "extensions": {
+        "website": "https://get.stokedtosendit.com"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "HNpdP2rL6FR6jM3bDxFX2Zo32D1YG2ZCztf9zzCrKMEX",
+      "symbol": "SER",
+      "name": "Secretum",
+      "decimals": 8,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/HNpdP2rL6FR6jM3bDxFX2Zo32D1YG2ZCztf9zzCrKMEX/logo.svg",
+      "tags": [],
+      "extensions": {
+        "website": "https://secretum.io/",
+        "twitter": "https://twitter.com/appsecretum",
+        "telegram": "https://t.me/joinchat/ZTXM0J9pOMozOGY0"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "3NcCuwvTMnnf7TU2UEVhp6v2nzbLXQiDgzQySS6m8A7P",
+      "symbol": "SQUIDGAME",
+      "name": "Squid Game",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/3NcCuwvTMnnf7TU2UEVhp6v2nzbLXQiDgzQySS6m8A7P/logo.png",
+      "tags": [
+        "Meme",
+        "community"
+      ],
+      "extensions": {
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "7S5QMfpwnai8nF8RmHnwfGDQwGa2TURDvkHXH17tMjdn",
+      "symbol": "betaFANT",
+      "name": "betaFANT",
+      "decimals": 6,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/7S5QMfpwnai8nF8RmHnwfGDQwGa2TURDvkHXH17tMjdn/logo.png",
+      "tags": [
+        "dumby-token"
+      ],
+      "extensions": {
+        "website": "https://phantasia.app/",
+        "twitter": "https://twitter.com/PhantasiaSports",
+        "email": "phantasia@phantasia.digital",
+        "discord": "https://t.co/Vskz9PkBBC?amp=1"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "ArhMyF2N8XpaujYUxTTDt9EuaBCaGaccxfwaZmkm9XeF",
+      "symbol": "DOGETH",
+      "name": "Doge Thug",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/ArhMyF2N8XpaujYUxTTDt9EuaBCaGaccxfwaZmkm9XeF/logo.png",
+      "tags": [
+        "Meme",
+        "Social",
+        "Metaverse"
+      ],
+      "extensions": {
+        "website": "https://dogethug.samoymeme.com",
+        "serumV3Usdc": "F1jBaKCMrxZpEgn79uduxpF2qHeqwiTQ3BwKdT6yqckd"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "D8Fc2HLd9L9V2mJnEUpnys6muJUawKYFnJWcUiaGKnyP",
+      "symbol": "OOAH",
+      "name": "OOAH Monkey",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/D8Fc2HLd9L9V2mJnEUpnys6muJUawKYFnJWcUiaGKnyP/logo.png",
+      "tags": [
+        "Meme",
+        "Social",
+        "Metaverse"
+      ],
+      "extensions": {
+        "website": "https://ooah.samoymeme.com",
+        "serumV3Usdc": "J6ih6rFbwkx7bMRZYjaFzkAUcsLrCMxZ9CCEbtyEAJbS"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "BjTUmZjNUUAPKHVdTs8yZsCmecW5isSK4AbuFihXoUwa",
+      "symbol": "PUSSY",
+      "name": "Pussy",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/BjTUmZjNUUAPKHVdTs8yZsCmecW5isSK4AbuFihXoUwa/logo.png",
+      "tags": [
+        "Meme",
+        "Social",
+        "Metaverse"
+      ],
+      "extensions": {
+        "website": "https://pussy.samoymeme.com",
+        "serumV3Usdc": "ALgq4dHm4bypcsg1JRDc6VPurwDtUsdsbpYB8kDxyZ9o"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "5xq71UHmPSZ5s68DkXL8wrBVsWCh4zXgcn4wTWkqFdxa",
+      "symbol": "JESUS",
+      "name": "JESUS",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/5xq71UHmPSZ5s68DkXL8wrBVsWCh4zXgcn4wTWkqFdxa/logo.png",
+      "tags": [
+        "Meme",
+        "Social",
+        "Community"
+      ],
+      "extensions": {
+        "website": "https://jesus.samoymeme.com",
+        "serumV3Usdc": "7h3Pda8GwRg83NifksuZNx9xBS6voe1DyxGrQb6JqfB7"
+      }
+    },
+    {
       "chainId": 101,
       "address": "AJpDoSsLpPpkFdph1EJCEh4fxpLuPE7NAWhqG5vVBeqa",
       "symbol": "CRY",
@@ -23768,219 +23896,227 @@
         "discord": "https://discord.gg/NDacA7b6AQ",
         "twitter": "https://twitter.com/crypunks"
       }
-}
-,
-{
-    "chainId": 101,
-    "address": "8xAKtGcMFfjzcN1AuGufkpSjKQ6i9xmZeW1GHNzSNE1j",
-    "symbol": "SOLGR",
-    "name": "SOL GOLDEN RETRIEVER",
-    "decimals": 9,
-    "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/8xAKtGcMFfjzcN1AuGufkpSjKQ6i9xmZeW1GHNzSNE1j/logo.png",
-    "tags": [
-      "Meme-token",
-      "DEFI",
-      "Dog",
-      "Community"
-  
-    ],
-    "extensions": {
-      "twitter":"https://twitter.com/SOLGR_Official",
-      "website": "https://sogrr.com",
-      "discord":"https://discord.gg/2ZPNmRrNpW",
-      "Telegram":"https://t.me/SOLGR_Official"
-    }
-  },
-{
-    "chainId": 101,
-    "address": "9CZHvdrHt48GMMz7EbQ7iQM3ShrUW6vroipVj3WWrdHA",
-    "symbol": "SOLGR",
-    "name": "SOL GOLDEN RETRIEVER",
-    "decimals": 9,
-    "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/8xAKtGcMFfjzcN1AuGufkpSjKQ6i9xmZeW1GHNzSNE1j/logo.png",
-    "tags": [
-      "Meme-token",
-      "DEFI",
-      "Dog",
-      "Community"
-  
-    ],
-    "extensions": {
-      "twitter":"https://twitter.com/SOLGR_Official",
-      "website": "https://solgrr.com",
-      "discord":"https://discord.gg/2ZPNmRrNpW",
-      "Telegram":"https://t.me/SOLGR_Official"
-    }
-  },
-{
-    "chainId": 101,
-    "address": "EjCtfmGrsWePGJmE46gvB9r6oVRErgA2JA4Q5T3k8dUj",
-    "symbol": "SOLGR",
-    "name": "SOL GOLDEN RETRIEVER",
-    "decimals": 9,
-    "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/EjCtfmGrsWePGJmE46gvB9r6oVRErgA2JA4Q5T3k8dUj/logo.png",
-    "tags": [
-      "Meme-token",
-      "DEFI",
-      "Dog",
-      "Community"
-  
-    ],
-    "extensions": {
-      "twitter":"https://twitter.com/SOLGR_Official",
-      "website": "https://solgrr.com",
-      "discord":"https://discord.gg/2ZPNmRrNpW",
-      "Telegram":"https://t.me/SOLGR_Official"
-    }
-  },
-{
-    "chainId": 101,
-    "address": "4ZEDNmqoLbzwJVAJZNhRgz31Da8DauDkpSfH9iU2vXA4",
-    "symbol": "CATOMIAOU",
-    "name": "Cato Miaouss",
-    "decimals": 9,
-    "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/4ZEDNmqoLbzwJVAJZNhRgz31Da8DauDkpSfH9iU2vXA4/logo.png",
-    "tags": [
-        "Meme", "community"
-    ],
-    "extensions": {
+    },
+    {
+      "chainId": 101,
+      "address": "8xAKtGcMFfjzcN1AuGufkpSjKQ6i9xmZeW1GHNzSNE1j",
+      "symbol": "SOLGR",
+      "name": "SOL GOLDEN RETRIEVER",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/8xAKtGcMFfjzcN1AuGufkpSjKQ6i9xmZeW1GHNzSNE1j/logo.png",
+      "tags": [
+        "Meme-token",
+        "DEFI",
+        "Dog",
+        "Community"
+      ],
+      "extensions": {
+        "twitter": "https://twitter.com/SOLGR_Official",
+        "website": "https://sogrr.com",
+        "discord": "https://discord.gg/2ZPNmRrNpW",
+        "Telegram": "https://t.me/SOLGR_Official"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "9CZHvdrHt48GMMz7EbQ7iQM3ShrUW6vroipVj3WWrdHA",
+      "symbol": "SOLGR",
+      "name": "SOL GOLDEN RETRIEVER",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/8xAKtGcMFfjzcN1AuGufkpSjKQ6i9xmZeW1GHNzSNE1j/logo.png",
+      "tags": [
+        "Meme-token",
+        "DEFI",
+        "Dog",
+        "Community"
+      ],
+      "extensions": {
+        "twitter": "https://twitter.com/SOLGR_Official",
+        "website": "https://solgrr.com",
+        "discord": "https://discord.gg/2ZPNmRrNpW",
+        "Telegram": "https://t.me/SOLGR_Official"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "EjCtfmGrsWePGJmE46gvB9r6oVRErgA2JA4Q5T3k8dUj",
+      "symbol": "SOLGR",
+      "name": "SOL GOLDEN RETRIEVER",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/EjCtfmGrsWePGJmE46gvB9r6oVRErgA2JA4Q5T3k8dUj/logo.png",
+      "tags": [
+        "Meme-token",
+        "DEFI",
+        "Dog",
+        "Community"
+      ],
+      "extensions": {
+        "twitter": "https://twitter.com/SOLGR_Official",
+        "website": "https://solgrr.com",
+        "discord": "https://discord.gg/2ZPNmRrNpW",
+        "Telegram": "https://t.me/SOLGR_Official"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "4ZEDNmqoLbzwJVAJZNhRgz31Da8DauDkpSfH9iU2vXA4",
+      "symbol": "CATOMIAOU",
+      "name": "Cato Miaouss",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/4ZEDNmqoLbzwJVAJZNhRgz31Da8DauDkpSfH9iU2vXA4/logo.png",
+      "tags": [
+        "Meme",
+        "community"
+      ],
+      "extensions": {
         "website": "https://catomiaouss.samoymeme.com",
         "serumV3Usdc": "FFJpw24jsFWgjcJKffjBc9FzAeoMpzedHBn9WhwwtcmD"
-    }
-},
-{
-    "chainId": 101,
-    "address": "AMNoi4727tzy7adu4wnx3cN2VQbQdG71DqaPoSm7isJ3",
-    "symbol": "BITCH",
-    "name": "Bitch Of Solana",
-    "decimals": 9,
-    "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/AMNoi4727tzy7adu4wnx3cN2VQbQdG71DqaPoSm7isJ3/logo.png",
-    "tags": [
-        "Meme", "community","utility-token"
-    ],
-    "extensions": {
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "AMNoi4727tzy7adu4wnx3cN2VQbQdG71DqaPoSm7isJ3",
+      "symbol": "BITCH",
+      "name": "Bitch Of Solana",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/AMNoi4727tzy7adu4wnx3cN2VQbQdG71DqaPoSm7isJ3/logo.png",
+      "tags": [
+        "Meme",
+        "community",
+        "utility-token"
+      ],
+      "extensions": {
         "website": "https://bitch.samoymeme.com",
         "serumV3Usdc": "2N78M8HZj2R9rSHxVXx6QWSvFvvnmhoEbsNPfrBdtdGo"
-    }
-},
-{
-    "chainId": 101,
-    "address": "HdjMPYYKaAgHr6Son56hGaSP3CEkDvD67bVzGuVgfz8S",
-    "symbol": "SHIBETOSHI",
-    "name": "Shibetoshi Nakamoto",
-    "decimals": 9,
-    "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/HdjMPYYKaAgHr6Son56hGaSP3CEkDvD67bVzGuVgfz8S/logo.png",
-    "tags": [
-        "meme", "community","NFTs","DEFI",
-      "Dog"
-    ],
-    "extensions": {
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "HdjMPYYKaAgHr6Son56hGaSP3CEkDvD67bVzGuVgfz8S",
+      "symbol": "SHIBETOSHI",
+      "name": "Shibetoshi Nakamoto",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/HdjMPYYKaAgHr6Son56hGaSP3CEkDvD67bVzGuVgfz8S/logo.png",
+      "tags": [
+        "meme",
+        "community",
+        "NFTs",
+        "DEFI",
+        "Dog"
+      ],
+      "extensions": {
         "website": "https://www.billym2k.net/",
-        "serumV3Usdc": "91WiupLKLjP8ENihdgiZ53j49aosNm1EYXdLbRD6GAY4"
-	,"twitter":"https://twitter.com/shibetoshi_naka"
-    }
-},
-{
-    "chainId": 101,
-    "address": "4ZwWddrPzfgMxyEgQ7kzVrqoqX5D9BQJPwduQUBMmePs",
-    "symbol": "APEM",
-    "name": "APEMOON",
-    "decimals": 9,
-    "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/4ZwWddrPzfgMxyEgQ7kzVrqoqX5D9BQJPwduQUBMmePs/logo.png",
-    "tags": [
-      "Meme-token",
-      "DEFI",
-      "Community"
-  
-    ],
-    "extensions": {
-      "twitter":"https://twitter.com/ApemoonSOL",
-      "website": "https://t.me/ApeMoonSOL",
-      "Telegram":"https://t.me/ApeMoonSOL"
-    }
-  },
-{
-    "chainId": 101,
-    "address": "7YhfUG27m7ceDCBnB48dGy4mAJab2hqi6YKkp9Ho7ybv",
-    "symbol": "BANANA",
-    "name": "Banana Bucks",
-    "decimals": 2,
-    "logoURI": "https://i.ibb.co/DMQNjc0/bananabucks-thumbnail.jpg",
-    "tags": [
-      "meme-token",
-      "community"
-    ],
-    "extensions": {
-      "twitter":"https://twitter.com/solbananabucks",
-      "Discord": "https://discord.gg/DVH2ggAc"
-    }
-  },
-{
-    "chainId": 101,
-    "address": "QuYNbuTjnAUQ8YxtrmGfu8P1UAEvcG3CngFpXCo3Cts",
-    "symbol": "APEM",
-    "name": "APEMOON",
-    "decimals": 9,
-    "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/QuYNbuTjnAUQ8YxtrmGfu8P1UAEvcG3CngFpXCo3Cts/logo.png",
-    "tags": [
-      "Meme-token",
-      "DEFI",
-      "Community"
-  
-    ],
-    "extensions": {
-      "twitter":"https://twitter.com/ApemoonSOL",
-      "website": "https://t.me/ApeMoonSOL",
-      "Telegram":"https://t.me/ApeMoonSOL"
-    }
-  },
-{
-    "chainId": 101,
-    "address": "BKGp1At3yLDK1NE2gfMuwv1QMAHBwnqgSdULsyzjUagA",
-    "symbol": "KissMe",
-    "name": "Kiss Me ",
-    "decimals": 9,
-    "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/BKGp1At3yLDK1NE2gfMuwv1QMAHBwnqgSdULsyzjUagA/logo.png",
-    "tags": [
-        "meme", "community","utility-token"
-    ],
-    "extensions": {
+        "serumV3Usdc": "91WiupLKLjP8ENihdgiZ53j49aosNm1EYXdLbRD6GAY4",
+        "twitter": "https://twitter.com/shibetoshi_naka"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "4ZwWddrPzfgMxyEgQ7kzVrqoqX5D9BQJPwduQUBMmePs",
+      "symbol": "APEM",
+      "name": "APEMOON",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/4ZwWddrPzfgMxyEgQ7kzVrqoqX5D9BQJPwduQUBMmePs/logo.png",
+      "tags": [
+        "Meme-token",
+        "DEFI",
+        "Community"
+      ],
+      "extensions": {
+        "twitter": "https://twitter.com/ApemoonSOL",
+        "website": "https://t.me/ApeMoonSOL",
+        "Telegram": "https://t.me/ApeMoonSOL"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "7YhfUG27m7ceDCBnB48dGy4mAJab2hqi6YKkp9Ho7ybv",
+      "symbol": "BANANA",
+      "name": "Banana Bucks",
+      "decimals": 2,
+      "logoURI": "https://i.ibb.co/DMQNjc0/bananabucks-thumbnail.jpg",
+      "tags": [
+        "meme-token",
+        "community"
+      ],
+      "extensions": {
+        "twitter": "https://twitter.com/solbananabucks",
+        "Discord": "https://discord.gg/DVH2ggAc"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "QuYNbuTjnAUQ8YxtrmGfu8P1UAEvcG3CngFpXCo3Cts",
+      "symbol": "APEM",
+      "name": "APEMOON",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/QuYNbuTjnAUQ8YxtrmGfu8P1UAEvcG3CngFpXCo3Cts/logo.png",
+      "tags": [
+        "Meme-token",
+        "DEFI",
+        "Community"
+      ],
+      "extensions": {
+        "twitter": "https://twitter.com/ApemoonSOL",
+        "website": "https://t.me/ApeMoonSOL",
+        "Telegram": "https://t.me/ApeMoonSOL"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "BKGp1At3yLDK1NE2gfMuwv1QMAHBwnqgSdULsyzjUagA",
+      "symbol": "KissMe",
+      "name": "Kiss Me ",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/BKGp1At3yLDK1NE2gfMuwv1QMAHBwnqgSdULsyzjUagA/logo.png",
+      "tags": [
+        "meme",
+        "community",
+        "utility-token"
+      ],
+      "extensions": {
         "website": "https://kissme.samoymeme.com",
         "serumV3Usdc": "91WiupLKLjP8ENihdgiZ53j49aosNm1EYXdLbRD6GAY4"
-    }
-},
-{
-    "chainId": 101,
-    "address": "3in9a9yHtdjDFRjDyGTTpGUwJpT9zZBcyjQ8J7nqqNtq",
-    "symbol": "DoggyStyle",
-    "name": "Doggy Style",
-    "decimals": 9,
-    "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/3in9a9yHtdjDFRjDyGTTpGUwJpT9zZBcyjQ8J7nqqNtq/logo.png",
-    "tags": [
-        "Meme", "community","utility-token"
-    ],
-    "extensions": {
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "3in9a9yHtdjDFRjDyGTTpGUwJpT9zZBcyjQ8J7nqqNtq",
+      "symbol": "DoggyStyle",
+      "name": "Doggy Style",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/3in9a9yHtdjDFRjDyGTTpGUwJpT9zZBcyjQ8J7nqqNtq/logo.png",
+      "tags": [
+        "Meme",
+        "community",
+        "utility-token"
+      ],
+      "extensions": {
         "website": "https://doggystyle.samoymeme.com",
         "serumV3Usdc": "yzKcpbgRmwE5ULL72C4JPUZYQ2S8ZHRFJnrXgQrKyvB"
-    }
-},
-{
-    "chainId": 101,
-    "address": "osRA9qNxrtxF4kPAucsv9xHTu4YDrH6TqMMt9B2PsHa",
-    "symbol": "SHIBETOSHI",
-    "name": "Shibetoshi Nakamoto",
-    "decimals": 9,
-    "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/osRA9qNxrtxF4kPAucsv9xHTu4YDrH6TqMMt9B2PsHa/logo.png",
-    "tags": [
-        "meme", "community","NFTs","DEFI",
-      "Dog"
-    ],
-    "extensions": {
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "osRA9qNxrtxF4kPAucsv9xHTu4YDrH6TqMMt9B2PsHa",
+      "symbol": "SHIBETOSHI",
+      "name": "Shibetoshi Nakamoto",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/osRA9qNxrtxF4kPAucsv9xHTu4YDrH6TqMMt9B2PsHa/logo.png",
+      "tags": [
+        "meme",
+        "community",
+        "NFTs",
+        "DEFI",
+        "Dog"
+      ],
+      "extensions": {
         "website": "https://www.billym2k.net/",
-	"twitter":"https://twitter.com/BillyM2k"
-    }
-},
-{  "chainId": 101,
+        "twitter": "https://twitter.com/BillyM2k"
+      }
+    },
+    {
+      "chainId": 101,
       "address": "FEdyfKQi9hoS5RtX7UMsof12UZvary8ahxHaLJUVaduX",
       "symbol": "YII",
       "name": "YIICoin",
@@ -23992,116 +24128,135 @@
       "extensions": {
         "website": "https://dockcoin.me/"
       }
-},
-{  "chainId": 101,
+    },
+    {
+      "chainId": 101,
       "address": "GEdo2wNT5DDy7pQqApKrpc7MVnLmC3GJnb55iRmGieAi",
       "symbol": "DogeKing",
       "name": "Doge King",
       "decimals": 0,
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/GEdo2wNT5DDy7pQqApKrpc7MVnLmC3GJnb55iRmGieAi/logo.png",
       "tags": [
-        "meme-token", "DOGE","NFT", "community"
+        "meme-token",
+        "DOGE",
+        "NFT",
+        "community"
       ],
       "extensions": {
-        "twitter": "https://twitter.com/DogeKing_SOL"
-	 
-, 
+        "twitter": "https://twitter.com/DogeKing_SOL",
         "website": "https://solscan.io/token/GEdo2wNT5DDy7pQqApKrpc7MVnLmC3GJnb55iRmGieAi"
       }
-},
-{  "chainId": 101,
+    },
+    {
+      "chainId": 101,
       "address": "CPL7TvVnQXQ8aN2DytF53uskyYAVxgNx5z2waJrc3Cev",
       "symbol": "Cate",
       "name": "CateCoin SOL",
       "decimals": 0,
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/CPL7TvVnQXQ8aN2DytF53uskyYAVxgNx5z2waJrc3Cev/logo.png",
       "tags": [
-        "meme-token", "CATE","NFT", "community"
+        "meme-token",
+        "CATE",
+        "NFT",
+        "community"
       ],
       "extensions": {
-        "twitter": "https://twitter.com/CatecoinSol"
-
-,  "website": "https://solscan.io/token/CPL7TvVnQXQ8aN2DytF53uskyYAVxgNx5z2waJrc3Cev"
+        "twitter": "https://twitter.com/CatecoinSol",
+        "website": "https://solscan.io/token/CPL7TvVnQXQ8aN2DytF53uskyYAVxgNx5z2waJrc3Cev"
       }
-},
-{  "chainId": 101,
+    },
+    {
+      "chainId": 101,
       "address": "BWm92csusaUNPWu8M2aC2UTcGQVJsrhH7JYtd47zN7FA",
       "symbol": "DOELON",
       "name": "Dogs Of Elon",
       "decimals": 9,
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/BWm92csusaUNPWu8M2aC2UTcGQVJsrhH7JYtd47zN7FA/logo.png",
       "tags": [
-        "meme-token", "DOGE","NFT", "community"
+        "meme-token",
+        "DOGE",
+        "NFT",
+        "community"
       ],
       "extensions": {
-        "twitter": "https://twitter.com/ElonDogs"
-
-       , "website": "https://solscan.io/token/BWm92csusaUNPWu8M2aC2UTcGQVJsrhH7JYtd47zN7FA"
-	 
+        "twitter": "https://twitter.com/ElonDogs",
+        "website": "https://solscan.io/token/BWm92csusaUNPWu8M2aC2UTcGQVJsrhH7JYtd47zN7FA"
       }
-},
-{  "chainId": 101,
+    },
+    {
+      "chainId": 101,
       "address": "EpxkCmZT9MmGe2UfpH7zFEhpi8RknT4BwG2VyGJPG4Ps",
       "symbol": "CUMSTAR",
       "name": "CumStar SOL",
       "decimals": 0,
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/EpxkCmZT9MmGe2UfpH7zFEhpi8RknT4BwG2VyGJPG4Ps/logo.png",
       "tags": [
-        "Application", "Payment","NFT", "community"
+        "Application",
+        "Payment",
+        "NFT",
+        "community"
       ],
       "extensions": {
-        "twitter": "https://twitter.com/CumStarSol"
-, 
+        "twitter": "https://twitter.com/CumStarSol",
         "website": "https://solscan.io/token/EpxkCmZT9MmGe2UfpH7zFEhpi8RknT4BwG2VyGJPG4Ps"
-
       }
-},
-{  "chainId": 101,
+    },
+    {
+      "chainId": 101,
       "address": "F5f9hLQ6FNHwuU3dS8CUCRy9r2deJXYCinDL6RAxsPeX",
       "symbol": "BABYFLOKISOL",
       "name": "Baby Floki Doge",
       "decimals": 9,
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/F5f9hLQ6FNHwuU3dS8CUCRy9r2deJXYCinDL6RAxsPeX/logo.png",
       "tags": [
-        "meme-token", "DOGE","NFT", "community"
+        "meme-token",
+        "DOGE",
+        "NFT",
+        "community"
       ],
       "extensions": {
         "website": "https://solscan.io/token/F5f9hLQ6FNHwuU3dS8CUCRy9r2deJXYCinDL6RAxsPeX"
-         
       }
-},
-{  "chainId": 101,
+    },
+    {
+      "chainId": 101,
       "address": "39cG39AZ4cG7oGNMe4RhD3xAzjy1nkiNgk8W6WbDCgeR",
       "symbol": "XHamster",
       "name": "xHamster",
       "decimals": 0,
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/39cG39AZ4cG7oGNMe4RhD3xAzjy1nkiNgk8W6WbDCgeR/logo.png",
       "tags": [
-        "Payment Protocol", "Payment","Videos", "community", "Live Stream"
+        "Payment Protocol",
+        "Payment",
+        "Videos",
+        "community",
+        "Live Stream"
       ],
       "extensions": {
-        "twitter": "https://twitter.com/xhamster_sol"
-
-       , "website": "https://solscan.io/token/39cG39AZ4cG7oGNMe4RhD3xAzjy1nkiNgk8W6WbDCgeR"
-
+        "twitter": "https://twitter.com/xhamster_sol",
+        "website": "https://solscan.io/token/39cG39AZ4cG7oGNMe4RhD3xAzjy1nkiNgk8W6WbDCgeR"
       }
-},
-{  "chainId": 101,
+    },
+    {
+      "chainId": 101,
       "address": "Fkbimv9CBGZANAqRJZQ732xEZ5EA4GidjeNRKiYoDY5y",
       "symbol": "FLOKI",
       "name": "Floki Inu SOL",
       "decimals": 9,
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/Fkbimv9CBGZANAqRJZQ732xEZ5EA4GidjeNRKiYoDY5y/logo.png",
       "tags": [
-        "meme-token", "DOGE","NFT", "community", "FLOKI"
+        "meme-token",
+        "DOGE",
+        "NFT",
+        "community",
+        "FLOKI"
       ],
       "extensions": {
-        "twitter": "https://twitter.com/floki_sol"
-
-, "website": "https://solscan.io/token/Fkbimv9CBGZANAqRJZQ732xEZ5EA4GidjeNRKiYoDY5y"
+        "twitter": "https://twitter.com/floki_sol",
+        "website": "https://solscan.io/token/Fkbimv9CBGZANAqRJZQ732xEZ5EA4GidjeNRKiYoDY5y"
       }
-},
-{
+    },
+    {
       "chainId": 101,
       "address": "3fFHsncY59ue2HPduo1KhbZRWYRd8iek5tj88sPXMgFk",
       "symbol": "FLOKI",
@@ -24109,15 +24264,17 @@
       "decimals": 9,
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/3fFHsncY59ue2HPduo1KhbZRWYRd8iek5tj88sPXMgFk/logo.png",
       "tags": [
-        "community-token", "meme-token", "doge","Floki"
+        "community-token",
+        "meme-token",
+        "doge",
+        "Floki"
       ],
       "extensions": {
-        "twitter": "https://twitter.com/FlokiVikingSOL"
-, "website": "https://solscan.io/token/3fFHsncY59ue2HPduo1KhbZRWYRd8iek5tj88sPXMgFk"
-
+        "twitter": "https://twitter.com/FlokiVikingSOL",
+        "website": "https://solscan.io/token/3fFHsncY59ue2HPduo1KhbZRWYRd8iek5tj88sPXMgFk"
       }
     },
-{
+    {
       "chainId": 101,
       "address": "37mG5XYuwMSutQnvERDUZqxumes5hYp89X2gpBbedpZ2",
       "symbol": "ELON",
@@ -24125,80 +24282,90 @@
       "decimals": 9,
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/37mG5XYuwMSutQnvERDUZqxumes5hYp89X2gpBbedpZ2/logo.png",
       "tags": [
-        "community-token", "meme-token", "doge", "MUSK"
+        "community-token",
+        "meme-token",
+        "doge",
+        "MUSK"
       ],
       "extensions": {
-        "twitter": "https://twitter.com/DogeElonMarsSol"
-, "website": "https://solscan.io/token/37mG5XYuwMSutQnvERDUZqxumes5hYp89X2gpBbedpZ2"
-
-
+        "twitter": "https://twitter.com/DogeElonMarsSol",
+        "website": "https://solscan.io/token/37mG5XYuwMSutQnvERDUZqxumes5hYp89X2gpBbedpZ2"
       }
     },
-{
-  "chainId": 101,
-  "address": "ApSAjELw31MrMMxWXPeSrsDaakmA66XE1gpJKJhhh5ix",
-  "symbol": "FJB",
-  "name": "FJB",
-  "decimals": 9 ,
-  "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/ApSAjELw31MrMMxWXPeSrsDaakmA66XE1gpJKJhhh5ix/logo.png",
-  "tags": [
-    "meme-token"
-  ],
-  "extensions": {
-    "website": "http://OfficialFJB.com",
-    "twitter": "https://twitter.com/official_fjb",
-    "instagram": "https://www.instagram.com/official_fjb"
-  }
-},
-{  "chainId": 101,
+    {
+      "chainId": 101,
+      "address": "ApSAjELw31MrMMxWXPeSrsDaakmA66XE1gpJKJhhh5ix",
+      "symbol": "FJB",
+      "name": "FJB",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/ApSAjELw31MrMMxWXPeSrsDaakmA66XE1gpJKJhhh5ix/logo.png",
+      "tags": [
+        "meme-token"
+      ],
+      "extensions": {
+        "website": "http://OfficialFJB.com",
+        "twitter": "https://twitter.com/official_fjb",
+        "instagram": "https://www.instagram.com/official_fjb"
+      }
+    },
+    {
+      "chainId": 101,
       "address": "6cH34XtzNgCDwb7NFbiji1a1N8F3FgmXTrFxvzBZNVui",
       "symbol": "KINGSHIB",
       "name": "King Shiba",
       "decimals": 9,
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/6cH34XtzNgCDwb7NFbiji1a1N8F3FgmXTrFxvzBZNVui/logo.png",
       "tags": [
-         "meme", "community","NFTs","DEFI",
-      "Dog"
+        "meme",
+        "community",
+        "NFTs",
+        "DEFI",
+        "Dog"
       ],
       "extensions": {
         "website": "https://www.kingshibaofficial.com/",
-	"twitter":"https://twitter.com/kingshiba_sol"
-	, "website": "https://solscan.io/token/6cH34XtzNgCDwb7NFbiji1a1N8F3FgmXTrFxvzBZNVui"
-, "website": "https://trade.dexlab.space/#/market/6zH7zwXKyTCUFEGGSjzr4ndegLLPGRAhT2mfcWc6wP1w"
+        "twitter": "https://twitter.com/kingshiba_sol",
+        "website": "https://solscan.io/token/6cH34XtzNgCDwb7NFbiji1a1N8F3FgmXTrFxvzBZNVui",
+        "website": "https://trade.dexlab.space/#/market/6zH7zwXKyTCUFEGGSjzr4ndegLLPGRAhT2mfcWc6wP1w"
       }
-},
-{  "chainId": 101,
+    },
+    {
+      "chainId": 101,
       "address": "B8NrYG3ZGbmDS6Xv5PUSdpJmXor9VvtxibvDRKNq3rnc",
       "symbol": "METASOL",
       "name": "META SOL",
       "decimals": 9,
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/B8NrYG3ZGbmDS6Xv5PUSdpJmXor9VvtxibvDRKNq3rnc/logo.png",
       "tags": [
-          "community","NFTs","DEFI","Facebook"
+        "community",
+        "NFTs",
+        "DEFI",
+        "Facebook"
       ],
       "extensions": {
-	"twitter":"https://twitter.com/MetaSol2"
-        
+        "twitter": "https://twitter.com/MetaSol2"
       }
-},
-{
-  "chainId": 101,
-  "address": "9HEGaeiuK1YNq4v69kVXqF1ssnpndpkVE9hbo8PSftGh",
-  "symbol": "RUGP",
-  "name": "Rug Pull Coin",
-  "decimals": 9,
-  "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/9HEGaeiuK1YNq4v69kVXqF1ssnpndpkVE9hbo8PSftGh/logo.png",
-  "tags": [
-    "social-token", "utility-token", "meme-token"
-  ],
-  "extensions": {
-    "website": "https://rug-pull-coin.com",
-    "twitter":"https://twitter.com/rug_puller",
-    "description": "This is a coin on a mission to inform you of the dangers investing & prevent you from being scammed."
-  }
-},
-
-{  "chainId": 101,
+    },
+    {
+      "chainId": 101,
+      "address": "9HEGaeiuK1YNq4v69kVXqF1ssnpndpkVE9hbo8PSftGh",
+      "symbol": "RUGP",
+      "name": "Rug Pull Coin",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/9HEGaeiuK1YNq4v69kVXqF1ssnpndpkVE9hbo8PSftGh/logo.png",
+      "tags": [
+        "social-token",
+        "utility-token",
+        "meme-token"
+      ],
+      "extensions": {
+        "website": "https://rug-pull-coin.com",
+        "twitter": "https://twitter.com/rug_puller",
+        "description": "This is a coin on a mission to inform you of the dangers investing & prevent you from being scammed."
+      }
+    },
+    {
+      "chainId": 101,
       "address": "8cDqXAoivNdvwd1sy74rTfMeYMM4J1u1ey8WRFYk5RD",
       "symbol": "YEE",
       "name": "YEECoin",
@@ -24210,17 +24377,21 @@
       "extensions": {
         "website": "https://solana-nft.io/"
       }
-},{
-  "chainId": 103,
-  "address": "9tjgbaSSEyPgRgTLVaTzzZR46xPq1jU6d7fB217czRdK",
-  "symbol": "QAI",
-  "name": "Quartic AI Token",
-  "decimals": 9,
-  "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/9tjgbaSSEyPgRgTLVaTzzZR46xPq1jU6d7fB217czRdK/logo.png",
-  "tags": [
-    "utility-token", "meme token"
-  ]
-},{  "chainId": 101,
+    },
+    {
+      "chainId": 103,
+      "address": "9tjgbaSSEyPgRgTLVaTzzZR46xPq1jU6d7fB217czRdK",
+      "symbol": "QAI",
+      "name": "Quartic AI Token",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/9tjgbaSSEyPgRgTLVaTzzZR46xPq1jU6d7fB217czRdK/logo.png",
+      "tags": [
+        "utility-token",
+        "meme token"
+      ]
+    },
+    {
+      "chainId": 101,
       "address": "7ouSGk4PvjczBVKqXaV5TCuYpZgw8KhcJovvUfyUdsSv",
       "symbol": "MBLZ",
       "name": "MARBLZ Coin",
@@ -24232,7 +24403,8 @@
       "extensions": {
         "website": "https://marblz.io/"
       }
-},{
+    },
+    {
       "chainId": 101,
       "address": "2vspUf3wUsTPARa7EngGD3uoU6YgT9HRDhFpTdxa7rrW",
       "symbol": "CRYO",
@@ -24249,36 +24421,38 @@
         "discord": "https://discord.gg/NDacA7b6AQ",
         "twitter": "https://twitter.com/crypunks"
       }
-},{
-  "chainId": 101,
-  "address": "3WLDzzYXvhAwyX4xLAVuvVHfh6Eoq8uieKC8HhmLAhDe",
-  "symbol": "DANDO",
-  "name": "Dancing Doge",
-  "decimals": 4,
-  "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/3WLDzzYXvhAwyX4xLAVuvVHfh6Eoq8uieKC8HhmLAhDe/logo.png",
-  "tags": [],
-  "extensions": {
-    "website": "https://dancingdoge.co/",
-    "twitter": "https://twitter.com/DandoToken"
-  }
-},
-{
-  "chainId": 101,
-  "address": "9K4uNquZjVSBBN6fBsp62gtYLropyAxAbdZC7D9XErih",
-  "symbol": "OPPA",
-  "name": "OPPA",
-  "decimals": 9,
-  "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/9K4uNquZjVSBBN6fBsp62gtYLropyAxAbdZC7D9XErih/logo.png",
-  "tags": [
-    "community-token","utility-token"
-  ],
-  "extensions": {
-    "website": "https://nft.heyoppa.com/",
-    "discord":"https://discord.gg/XN6CbxD6m7",
-    "twitter":"https://twitter.com/OppaNFT"
-  }
-},
-{
+    },
+    {
+      "chainId": 101,
+      "address": "3WLDzzYXvhAwyX4xLAVuvVHfh6Eoq8uieKC8HhmLAhDe",
+      "symbol": "DANDO",
+      "name": "Dancing Doge",
+      "decimals": 4,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/3WLDzzYXvhAwyX4xLAVuvVHfh6Eoq8uieKC8HhmLAhDe/logo.png",
+      "tags": [],
+      "extensions": {
+        "website": "https://dancingdoge.co/",
+        "twitter": "https://twitter.com/DandoToken"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "9K4uNquZjVSBBN6fBsp62gtYLropyAxAbdZC7D9XErih",
+      "symbol": "OPPA",
+      "name": "OPPA",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/9K4uNquZjVSBBN6fBsp62gtYLropyAxAbdZC7D9XErih/logo.png",
+      "tags": [
+        "community-token",
+        "utility-token"
+      ],
+      "extensions": {
+        "website": "https://nft.heyoppa.com/",
+        "discord": "https://discord.gg/XN6CbxD6m7",
+        "twitter": "https://twitter.com/OppaNFT"
+      }
+    },
+    {
       "chainId": 101,
       "address": "5Rxq1GiVeuhhgcy3BEHLtjrHir1RKcNVpi5J6ZGMVDxj",
       "symbol": "BERS",
@@ -24297,110 +24471,111 @@
         "youtube": "https://www.youtube.com/c/BersCoinBersTube",
         "facebook": "https://www.facebook.com/berscoin",
         "founder": "https://montblanc.ovh"
-        }
-},
-{
-    "chainId": 101,
-    "address": "ZEExktbqMM5ZMS569pCNbzky92KeEmiFeVwR3exfBNn",
-    "symbol": "ZEE",
-    "name": "ZEE",
-    "decimals": 0,
-    "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/ZEExktbqMM5ZMS569pCNbzky92KeEmiFeVwR3exfBNn/logo.png",
-    "tags": [
-        "zoints"
-    ],
-    "extensions": {
-      "website": "https://zoints.com"
       }
-},
-{
-  "chainId": 101,
-  "address": "AymKzSDznoLT7Vhsb4wSRnCj1gjcG3zkgYFY8fxsHHer",
-  "symbol": "TICKET",
-  "name": "The Ticket Finance",
-  "decimals": 8,
-  "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/AymKzSDznoLT7Vhsb4wSRnCj1gjcG3zkgYFY8fxsHHer/logo.png",
-  "tags": [
-    "launchpad",
-    "dex",
-    "nft",
-    "defi",
-    "exchange"
-  ],
-  "extensions": {
-    "website": "https://theticket.finance",
-    "twitter": "https://twitter.com/TheTicketSol"
-  }
-},    {
-  "chainId": 101,
-  "address": "2vfgEPJStq761qrkyh8xedrj9zpew1GQ8CobjtQ4wtyM",
-  "symbol": "BOO",
-  "name": "BOO",
-  "decimals": 9,
-  "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/2vfgEPJStq761qrkyh8xedrj9zpew1GQ8CobjtQ4wtyM/logo.png",
-  "tags": [],
-  "extensions": {
-    "website": "https://www.solaghosts.io",
-    "twitter": "https://twitter.com/solaghosts"
-  }
-	      },    {
-          "chainId": 101,
-          "address":  "CSQn7G3SmbBVFRMvNH5SJV5sd2HipWSCphfDVcXwY3K6",
-          "symbol": "DANG",
-          "name": "DANG",
-          "decimals": 5,
-          "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/CSQn7G3SmbBVFRMvNH5SJV5sd2HipWSCphfDVcXwY3K6/logo.png",
-          "tags": [],
-          "extensions": {
-            "website": "https://dang.gg"
-          }
-},
-		{
-		"chainId": 101,
-		"address": "J9yYvSXrtMV749XAbcFeMFpeY4AFwkFq9WpNDmmfV81Q",
-		"symbol": "POCH",
-		"name": "Poochu Coin",
-		"decimals": 9,
-		"logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/J9yYvSXrtMV749XAbcFeMFpeY4AFwkFq9WpNDmmfV81Q/logo.png",
-		"tags": [
-			"stake-pool-token",
-			"utility-token",
-			"meme-token",
-			"community-token"
-		]
-	
-},
+    },
     {
-    "chainId": 101,
-    "address": "G5gqGPsrpkRYZPThJJpoVQRtgjo8zapPZ27iCSp2wPX",
-    "symbol": "AGG",
-    "name": "Aggie Coin",
-    "decimals": 8,
-    "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/G5gqGPsrpkRYZPThJJpoVQRtgjo8zapPZ27iCSp2wPX/logo.png",
-    "tags": [
-      "aggie",
-      "aggie-token"
-    ]
-
-}
-,{
-    "chainId": 101,
-    "address": "AVKnbqNQgXDY8kbnno9eSGfwpVz5idimBnDKiz1vbWAh",
-    "symbol": "PART",
-    "name": "Particle",
-    "decimals": 9,
-    "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/AVKnbqNQgXDY8kbnno9eSGfwpVz5idimBnDKiz1vbWAh/logo.png",
-    "tags": [
-      "DeFi",
-      "NFT",
-      "Gaming"
-    ],
-"extensions": {
-            "website": "https://particle.technology/",
-             "twitter": "https://twitter.com/particle_techno"
-          }
-
-},{  "chainId": 101,
+      "chainId": 101,
+      "address": "ZEExktbqMM5ZMS569pCNbzky92KeEmiFeVwR3exfBNn",
+      "symbol": "ZEE",
+      "name": "ZEE",
+      "decimals": 0,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/ZEExktbqMM5ZMS569pCNbzky92KeEmiFeVwR3exfBNn/logo.png",
+      "tags": [
+        "zoints"
+      ],
+      "extensions": {
+        "website": "https://zoints.com"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "AymKzSDznoLT7Vhsb4wSRnCj1gjcG3zkgYFY8fxsHHer",
+      "symbol": "TICKET",
+      "name": "The Ticket Finance",
+      "decimals": 8,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/AymKzSDznoLT7Vhsb4wSRnCj1gjcG3zkgYFY8fxsHHer/logo.png",
+      "tags": [
+        "launchpad",
+        "dex",
+        "nft",
+        "defi",
+        "exchange"
+      ],
+      "extensions": {
+        "website": "https://theticket.finance",
+        "twitter": "https://twitter.com/TheTicketSol"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "2vfgEPJStq761qrkyh8xedrj9zpew1GQ8CobjtQ4wtyM",
+      "symbol": "BOO",
+      "name": "BOO",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/2vfgEPJStq761qrkyh8xedrj9zpew1GQ8CobjtQ4wtyM/logo.png",
+      "tags": [],
+      "extensions": {
+        "website": "https://www.solaghosts.io",
+        "twitter": "https://twitter.com/solaghosts"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "CSQn7G3SmbBVFRMvNH5SJV5sd2HipWSCphfDVcXwY3K6",
+      "symbol": "DANG",
+      "name": "DANG",
+      "decimals": 5,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/CSQn7G3SmbBVFRMvNH5SJV5sd2HipWSCphfDVcXwY3K6/logo.png",
+      "tags": [],
+      "extensions": {
+        "website": "https://dang.gg"
+      }
+    },
+    {
+      "chainId": 101,
+      "address": "J9yYvSXrtMV749XAbcFeMFpeY4AFwkFq9WpNDmmfV81Q",
+      "symbol": "POCH",
+      "name": "Poochu Coin",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/J9yYvSXrtMV749XAbcFeMFpeY4AFwkFq9WpNDmmfV81Q/logo.png",
+      "tags": [
+        "stake-pool-token",
+        "utility-token",
+        "meme-token",
+        "community-token"
+      ]
+    },
+    {
+      "chainId": 101,
+      "address": "G5gqGPsrpkRYZPThJJpoVQRtgjo8zapPZ27iCSp2wPX",
+      "symbol": "AGG",
+      "name": "Aggie Coin",
+      "decimals": 8,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/G5gqGPsrpkRYZPThJJpoVQRtgjo8zapPZ27iCSp2wPX/logo.png",
+      "tags": [
+        "aggie",
+        "aggie-token"
+      ]
+    },
+    {
+      "chainId": 101,
+      "address": "AVKnbqNQgXDY8kbnno9eSGfwpVz5idimBnDKiz1vbWAh",
+      "symbol": "PART",
+      "name": "Particle",
+      "decimals": 9,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/AVKnbqNQgXDY8kbnno9eSGfwpVz5idimBnDKiz1vbWAh/logo.png",
+      "tags": [
+        "DeFi",
+        "NFT",
+        "Gaming"
+      ],
+      "extensions": {
+        "website": "https://particle.technology/",
+        "twitter": "https://twitter.com/particle_techno"
+      }
+    },
+    {
+      "chainId": 101,
       "address": "FFg7BMsmxiwVSrKXrKHrKEwaHTEYSUfdzBBCoJZfQsfo",
       "symbol": "GUA",
       "name": "Gua Coin",
@@ -24412,22 +24587,24 @@
       "extensions": {
         "website": "https://solana-nft.io/"
       }
-	  },
-	  {"chainId": 101,
-  "address": "HYoGYzMcbYq3tAvpg15d8VFYVHw6jWEVuGgpNTrG8hps",
-  "symbol": "DOGELON",
-  "name": "DOGELON SOLANA",
-  "decimals": 4,
-  "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/HYoGYzMcbYq3tAvpg15d8VFYVHw6jWEVuGgpNTrG8hps/logo.png",
-  "tags": [
-    "meme"
+    },
+    {
+      "chainId": 101,
+      "address": "HYoGYzMcbYq3tAvpg15d8VFYVHw6jWEVuGgpNTrG8hps",
+      "symbol": "DOGELON",
+      "name": "DOGELON SOLANA",
+      "decimals": 4,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/HYoGYzMcbYq3tAvpg15d8VFYVHw6jWEVuGgpNTrG8hps/logo.png",
+      "tags": [
+        "meme"
+      ],
+      "extensions": {
+        "website": "https://dogelonsol.io/",
+        "twitter": "https://twitter.com/DogelonSol",
+        "discord": "https://discord.com/invite/A89B9rsB"
+      }
+    }
   ],
-  "extensions": {
-    "website": "https://dogelonsol.io/",
-    "twitter": "https://twitter.com/DogelonSol",
-    "discord": "https://discord.com/invite/A89B9rsB"
-  }
-}],
   "version": {
     "major": 0,
     "minor": 3,
@@ -24467,8 +24644,8 @@
   ],
   "extensions": {
     "website": "https://solbunny.io",
-    "discord":"https://discord.gg/h7CZnKCb",
-    "twitter":"https://twitter.com/SolanaBunny"
+    "discord": "https://discord.gg/h7CZnKCb",
+    "twitter": "https://twitter.com/SolanaBunny"
   },
   "chainId": 103,
   "address": "RMRUKEmLrdjYSpd7gxQQ2y4VuFcM8jkanXaDNuMdaCZ",
@@ -24495,7 +24672,7 @@
     "meme-token"
   ],
   "extensions": {
-    "twitter":"https://twitter.com/SOLPANDS"
+    "twitter": "https://twitter.com/SOLPANDS"
   },
   "chainId": 101,
   "address": "6XWfkyg5mzGtKNftSDgYjyoPyUsLRf2rafj95XSFSFrr",
@@ -24503,35 +24680,31 @@
   "name": "Kitty Coin",
   "decimals": 6,
   "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/6XWfkyg5mzGtKNftSDgYjyoPyUsLRf2rafj95XSFSFrr/logo.png",
-    "tags": [
+  "tags": [
     "meme-token",
-	"kitty",
-	"cat"
+    "kitty",
+    "cat"
   ],
   "extensions": {
-	"twitter": "https://twitter.com/KittyCoinSolana"
-  }
-  ,
-  
-   "chainId": 101,
-      "address": "FZMcCAq9U65mymBjUxKXPUJehDJMLg54Ud5bTrmbaHYS",
-      "symbol": "DCN",
-      "name": "DoodleCoin",
-      "decimals": 9,
-      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/FZMcCAq9U65mymBjUxKXPUJehDJMLg54Ud5bTrmbaHYS/logo.png",
-      "tags": [
-        "meme-token"
-      ],
-      "extensions": {
-        "website": "https://doodlecoin.me/"
-      }
-	   ,
-  
+    "twitter": "https://twitter.com/KittyCoinSolana"
+  },
+  "chainId": 101,
+  "address": "FZMcCAq9U65mymBjUxKXPUJehDJMLg54Ud5bTrmbaHYS",
+  "symbol": "DCN",
+  "name": "DoodleCoin",
+  "decimals": 9,
+  "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/FZMcCAq9U65mymBjUxKXPUJehDJMLg54Ud5bTrmbaHYS/logo.png",
+  "tags": [
+    "meme-token"
+  ],
+  "extensions": {
+    "website": "https://doodlecoin.me/"
+  },
   "chainId": 101,
   "address": "DCDUaGKLHcwEXdd2MiUYmW4PFtzCfCxncUZ5UZyGxdqh",
   "symbol": "KATZ",
   "name": "MeerkatCoin",
-  "decimals": 9 ,
+  "decimals": 9,
   "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/DCDUaGKLHcwEXdd2MiUYmW4PFtzCfCxncUZ5UZyGxdqh/logo.png",
   "tags": [
     "community-token"
@@ -24540,14 +24713,12 @@
     "website": "https://meerkatmillionaires.club",
     "twitter": "https://twitter.com/mmccsolana",
     "discord": "https://discord.gg/ynkkE3raZf"
-  }
-  ,
-  
+  },
   "chainId": 101,
   "address": "GCxgQbbvJc4UyqGCsUAUa38npzZX27EMxZwckLuWeEkt",
   "symbol": "NUTS",
   "name": "NUTS",
-  "decimals": 9 ,
+  "decimals": 9,
   "logoURI": "https://user-images.githubusercontent.com/93886730/140664862-6dd80bff-be30-4c68-a978-fcb205011d61.png",
   "tags": [
     "community-token"
@@ -24556,38 +24727,33 @@
     "website": "https://ssa.gg",
     "twitter": "https://twitter.com/SSA_NFT",
     "discord": "https://discord.gg/SSANFT"
-  }
-  ,
- 
-   "chainId": 101,
-      "address": "9wPT3uJrH43TPPupYyaywXaaqBNLTxMDGoaAvnz4RMMR",
-      "symbol": "DKC",
-      "name": "DockCoin",
-      "decimals": 9,
-      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/9wPT3uJrH43TPPupYyaywXaaqBNLTxMDGoaAvnz4RMMR/logo.png",
-      "tags": [
-        "meme-token"
-      ],
-      "extensions": {
-        "website": "https://dockcoin.me/"
-      }
-	,
-	
-	"chainId": 101,
-      "address": "Bo2kpetkHvtdjASpeRRiugzmdFhvbVsCMH6aq4mNd8TL",
-      "symbol": "NETX",
-      "name": "Syncline Health Network",
-      "decimals": 9,
-      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/Bo2kpetkHvtdjASpeRRiugzmdFhvbVsCMH6aq4mNd8TL/logo.png",
-      "tags": [
-        "utility-token"
-      ],
-      "extensions": {
-        "website": "https://syncline.network",
-		"twitter ": "https://twitter.com/synclinenetwork",
-		"telegram ": "https://t.me/joinchat/SKSLdG0sF53TFK6_"
-      }
-      ,
+  },
+  "chainId": 101,
+  "address": "9wPT3uJrH43TPPupYyaywXaaqBNLTxMDGoaAvnz4RMMR",
+  "symbol": "DKC",
+  "name": "DockCoin",
+  "decimals": 9,
+  "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/9wPT3uJrH43TPPupYyaywXaaqBNLTxMDGoaAvnz4RMMR/logo.png",
+  "tags": [
+    "meme-token"
+  ],
+  "extensions": {
+    "website": "https://dockcoin.me/"
+  },
+  "chainId": 101,
+  "address": "Bo2kpetkHvtdjASpeRRiugzmdFhvbVsCMH6aq4mNd8TL",
+  "symbol": "NETX",
+  "name": "Syncline Health Network",
+  "decimals": 9,
+  "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/Bo2kpetkHvtdjASpeRRiugzmdFhvbVsCMH6aq4mNd8TL/logo.png",
+  "tags": [
+    "utility-token"
+  ],
+  "extensions": {
+    "website": "https://syncline.network",
+    "twitter ": "https://twitter.com/synclinenetwork",
+    "telegram ": "https://t.me/joinchat/SKSLdG0sF53TFK6_"
+  },
   "chainId": 101,
   "address": "6gNNYnBxXccu1PSzFDqhQdNACJNF7TEQc6kPQwZ8Zwv",
   "symbol": "INK",
@@ -24601,8 +24767,7 @@
     "website": "https://socialoctopus.io",
     "twitter": "https://twitter.com/socialoctopusio",
     "discord": "https://discord.gg/nSMc9EjvT4"
-  }
-      ,
+  },
   "chainId": 101,
   "address": "Ch9NFVk5sqEPQHtw2gJVgnHfTm7FW1JspYwc7SxLi6q3",
   "symbol": "MEND",
@@ -24614,9 +24779,7 @@
   "extensions": {
     "website": "https://mend.house",
     "twitter": "https://twitter.com/mendappinc"
-  }
-  
-  ,
+  },
   "chainId": 101,
   "address": "J9yYvSXrtMV749XAbcFeMFpeY4AFwkFq9WpNDmmfV81Q",
   "symbol": "POCH",
@@ -24624,38 +24787,35 @@
   "decimals": 9,
   "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/J9yYvSXrtMV749XAbcFeMFpeY4AFwkFq9WpNDmmfV81Q/logo.png",
   "tags": [
-	"stake-pool-token",
-	"utility-token",
-	"meme-token",
-	"community-token"
-  ]
-  
-,
- "chainId": 101,
- "address": "7YhfUG27m7ceDCBnB48dGy4mAJab2hqi6YKkp9Ho7ybv",
- "symbol": "BANANA",
- "name": "Banana Bucks",
- "decimals": 2,
- "logoURI": "https://i.ibb.co/DMQNjc0/bananabucks-thumbnail.jpg",
- "tags": [
-"meme-token"
- ],
- "extensions": {
-   "discord": "https://discord.gg/DVH2ggAc",
-   "twitter": "https://twitter.com/solbananabucks"
- },
- "chainId": 101,
- "address": "snowRZ1wtHa7eiBhJVUqkyFn8P8zwkmL4UTXU7Zdgbu",
- "symbol": "SNOW",
- "name": "Snowflake",
- "decimals": 6,
- "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/snowRZ1wtHa7eiBhJVUqkyFn8P8zwkmL4UTXU7Zdgbu/logo.png",
- "tags": [],
- "extensions": {
-   "website": "https://snowflake.so",
-   "twitter": "https://twitter.com/snowflake_sol"
- }
-,
+    "stake-pool-token",
+    "utility-token",
+    "meme-token",
+    "community-token"
+  ],
+  "chainId": 101,
+  "address": "7YhfUG27m7ceDCBnB48dGy4mAJab2hqi6YKkp9Ho7ybv",
+  "symbol": "BANANA",
+  "name": "Banana Bucks",
+  "decimals": 2,
+  "logoURI": "https://i.ibb.co/DMQNjc0/bananabucks-thumbnail.jpg",
+  "tags": [
+    "meme-token"
+  ],
+  "extensions": {
+    "discord": "https://discord.gg/DVH2ggAc",
+    "twitter": "https://twitter.com/solbananabucks"
+  },
+  "chainId": 101,
+  "address": "snowRZ1wtHa7eiBhJVUqkyFn8P8zwkmL4UTXU7Zdgbu",
+  "symbol": "SNOW",
+  "name": "Snowflake",
+  "decimals": 6,
+  "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/snowRZ1wtHa7eiBhJVUqkyFn8P8zwkmL4UTXU7Zdgbu/logo.png",
+  "tags": [],
+  "extensions": {
+    "website": "https://snowflake.so",
+    "twitter": "https://twitter.com/snowflake_sol"
+  },
   "chainId": 101,
   "address": "inL8PMVd6iiW3RCBJnr5AsrRN6nqr4BTrcNuQWQSkvY",
   "symbol": "IN",
@@ -24673,38 +24833,40 @@
     "website": "https://invictusdao.fi/",
     "twitter": "https://twitter.com/InvictusDAO",
     "discord": "http://discord.gg/invictusdao"
+  },
+  "chainId": 101,
+  "address": "7puG5H5Mc6QpvaXjAVLr6GnL5hhUMnpLcUm8G3mEsgHQ",
+  "symbol": "LEONIDAS",
+  "name": "Leonidas Token",
+  "decimals": 9,
+  "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/7puG5H5Mc6QpvaXjAVLr6GnL5hhUMnpLcUm8G3mEsgHQ/logo.png",
+  "tags": [
+    "community-token",
+    "utility-token",
+    "social-token",
+    "NFTs",
+    "DeFi"
+  ],
+  "extensions": {
+    "telegram": "https://www.t.me/leonidas_token",
+    "website": "https://www.leonidastoken.com",
+    "twitter": "https://www.twitter.com/leonidas_token",
+    "discord": "https://www.discord.com/invite/drN8FUruAu",
+    "instagram": "https://www.instagram.com/leonidas_token",
+    "reddit": "https://www.reddit.com/r/leonidas_token",
+    "medium": "https://leonidastoken.medium.com",
+    "serumV3Usdc": "DTEmm1nC7n8vb3KmVabT6dEEnSNeDXNu1jWN4u2DfD7Z"
+  },
+  "chainId": 101,
+  "address": "8pMdj3AvCV4EbqRBCHMyDAVeMtBmP4wMhCDXqAtFcAqD",
+  "symbol": "GROOT",
+  "name": "Groot",
+  "decimals": 9,
+  "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/8pMdj3AvCV4EbqRBCHMyDAVeMtBmP4wMhCDXqAtFcAqD/logo.png",
+  "tags": [
+    "meme-token"
+  ],
+  "extensions": {
+    "website": "https://groot.sol/"
   }
-,
-"chainId": 101,
-"address": "7puG5H5Mc6QpvaXjAVLr6GnL5hhUMnpLcUm8G3mEsgHQ",
-"symbol": "LEONIDAS",
-"name": "Leonidas Token",
-"decimals": 9,
-"logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/7puG5H5Mc6QpvaXjAVLr6GnL5hhUMnpLcUm8G3mEsgHQ/logo.png",
-"tags": [
-"community-token", "utility-token", "social-token", "NFTs", "DeFi"
-],
-"extensions": {
-"telegram": "https://www.t.me/leonidas_token",
-"website": "https://www.leonidastoken.com",
-"twitter": "https://www.twitter.com/leonidas_token",
-"discord": "https://www.discord.com/invite/drN8FUruAu",
-"instagram": "https://www.instagram.com/leonidas_token",
-"reddit": "https://www.reddit.com/r/leonidas_token",
-"medium": "https://leonidastoken.medium.com",
-"serumV3Usdc": "DTEmm1nC7n8vb3KmVabT6dEEnSNeDXNu1jWN4u2DfD7Z"
-}
-,
-"chainId": 101,
-"address": "8pMdj3AvCV4EbqRBCHMyDAVeMtBmP4wMhCDXqAtFcAqD",
-"symbol": "GROOT",
-"name": "Groot",
-"decimals": 9,
-"logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/8pMdj3AvCV4EbqRBCHMyDAVeMtBmP4wMhCDXqAtFcAqD/logo.png",
-"tags": [
-"meme-token"
-],
-"extensions": {
-"website": "https://groot.sol/"
-}
 }

--- a/src/tokens/solana.tokenlist.json
+++ b/src/tokens/solana.tokenlist.json
@@ -546,8 +546,7 @@
         "website": "https://astrapad.io/",
         "twitter": "https://twitter.com/astrapadio",
         "coingeckoId": "astrapad",
-        "telegram": "https://t.me/AstraPadANN",
-        "twitter": "https://twitter.com/AstraPad"
+        "telegram": "https://t.me/AstraPadANN"
       }
     },
     {
@@ -18769,7 +18768,6 @@
       "symbol": "ODC",
       "name": "OneDay Coin",
       "decimals": 9,
-      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/assets/GzN5Y1KoP6Yo6KYVYg7JfJ7Urs6oCrtLByHLeZ1ELAnx/logo.png",
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/GzN5Y1KoP6Yo6KYVYg7JfJ7Urs6oCrtLByHLeZ1ELAnx/logo.png",
       "tags": [],
       "extensions": {
@@ -20194,7 +20192,6 @@
       "symbol": "ROFL",
       "name": "ROFLSTOMP TOKEN",
       "decimals": 9,
-      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/assets/mainnet/4xAPLtoJn7J7ALhLh7jz4unZRRDjCogNbnkJ2xhkYedo/teamROFLtwitter.png",
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/4xAPLtoJn7J7ALhLh7jz4unZRRDjCogNbnkJ2xhkYedo/teamROFLtwitter.png",
       "tags": [
         "team-token",
@@ -20294,7 +20291,6 @@
       "name": "PHANT",
       "decimals": 9,
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/AKxR1NLTtPnsVcWwPSEGat1TC9da3Z2vX7sY4G7ZLj1r/logo.png",
-      "logoURI": "https://user-images.githubusercontent.com/92027847/136703420-7f327114-7295-4e94-b38d-77eb5cf76927.png",
       "tags": [
         "utility-token"
       ],
@@ -22477,8 +22473,6 @@
       "symbol": "FLOOF",
       "name": "FLOOF",
       "decimals": 9,
-      "logoURI": "https://github.com/GreenFailure/Floof/blob/b928ee6640e28695100b3bf5b1c98d74add84301/istockphoto-1303160539-612x612.jpg",
-      "logoURI": "https://raw.githubusercontent.com/GreenFailure/Floof/b928ee6640e28695100b3bf5b1c98d74add84301/istockphoto-1303160539-612x612.jpg",
       "logoURI": "https://raw.githubusercontent.com/GreenFailure/Floof/main/OkyT9kpz_400x400.png",
       "tags": [],
       "coingeckoId": "floof",
@@ -24322,9 +24316,7 @@
       ],
       "extensions": {
         "website": "https://www.kingshibaofficial.com/",
-        "twitter": "https://twitter.com/kingshiba_sol",
-        "website": "https://solscan.io/token/6cH34XtzNgCDwb7NFbiji1a1N8F3FgmXTrFxvzBZNVui",
-        "website": "https://trade.dexlab.space/#/market/6zH7zwXKyTCUFEGGSjzr4ndegLLPGRAhT2mfcWc6wP1w"
+        "twitter": "https://twitter.com/kingshiba_sol"
       }
     },
     {

--- a/src/tokens/solana.tokenlist.json
+++ b/src/tokens/solana.tokenlist.json
@@ -967,26 +967,6 @@
     },
     {
       "chainId": 101,
-      "address": "6SKogZxCWY9jKsKPMT3ChJUhQxAEeB6NjVidXQK6TEdW",
-      "symbol": "GDoge",
-      "name": "Golden Doge Solana",
-      "decimals": 1,
-      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/6SKogZxCWY9jKsKPMT3ChJUhQxAEeB6NjVidXQK6TEdW/Logo.png",
-      "tags": [
-        "community-token",
-        "meme-token",
-        "doge",
-        "dogecoin",
-        "shiba inu",
-        "Golden Doge"
-      ],
-      "extensions": {
-        "twitter": "https://twitter.com/GoldSolDoge",
-        "website": "https://http://www.goldsoldoge.com/"
-      }
-    },
-    {
-      "chainId": 101,
       "address": "B7RDhZ2iqE4FEwK5nfcZ9r2xhVL6rQJCo1dcjDXnF688",
       "symbol": "LAT",
       "name": "Latte",
@@ -24022,22 +24002,6 @@
     },
     {
       "chainId": 101,
-      "address": "7YhfUG27m7ceDCBnB48dGy4mAJab2hqi6YKkp9Ho7ybv",
-      "symbol": "BANANA",
-      "name": "Banana Bucks",
-      "decimals": 2,
-      "logoURI": "https://i.ibb.co/DMQNjc0/bananabucks-thumbnail.jpg",
-      "tags": [
-        "meme-token",
-        "community"
-      ],
-      "extensions": {
-        "twitter": "https://twitter.com/solbananabucks",
-        "Discord": "https://discord.gg/DVH2ggAc"
-      }
-    },
-    {
-      "chainId": 101,
       "address": "QuYNbuTjnAUQ8YxtrmGfu8P1UAEvcG3CngFpXCo3Cts",
       "symbol": "APEM",
       "name": "APEMOON",
@@ -24523,20 +24487,6 @@
     },
     {
       "chainId": 101,
-      "address": "J9yYvSXrtMV749XAbcFeMFpeY4AFwkFq9WpNDmmfV81Q",
-      "symbol": "POCH",
-      "name": "Poochu Coin",
-      "decimals": 9,
-      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/J9yYvSXrtMV749XAbcFeMFpeY4AFwkFq9WpNDmmfV81Q/logo.png",
-      "tags": [
-        "stake-pool-token",
-        "utility-token",
-        "meme-token",
-        "community-token"
-      ]
-    },
-    {
-      "chainId": 101,
       "address": "G5gqGPsrpkRYZPThJJpoVQRtgjo8zapPZ27iCSp2wPX",
       "symbol": "AGG",
       "name": "Aggie Coin",
@@ -24598,6 +24548,7 @@
       "chainId": 101,
       "address": "2kMjMxSLLY3RP1Svg8THnoiAfnaScAemGUhVRF9bYcC7",
       "symbol": "BPCoin",
+      "name": "BPCoin",
       "decimals": 9,
       "extensions": {
         "website": "https://bricks.properties",
@@ -24712,22 +24663,6 @@
         "website": "https://meerkatmillionaires.club",
         "twitter": "https://twitter.com/mmccsolana",
         "discord": "https://discord.gg/ynkkE3raZf"
-      }
-    },
-    {
-      "chainId": 101,
-      "address": "GCxgQbbvJc4UyqGCsUAUa38npzZX27EMxZwckLuWeEkt",
-      "symbol": "NUTS",
-      "name": "NUTS",
-      "decimals": 9,
-      "logoURI": "https://user-images.githubusercontent.com/93886730/140664862-6dd80bff-be30-4c68-a978-fcb205011d61.png",
-      "tags": [
-        "community-token"
-      ],
-      "extensions": {
-        "website": "https://ssa.gg",
-        "twitter": "https://twitter.com/SSA_NFT",
-        "discord": "https://discord.gg/SSANFT"
       }
     },
     {

--- a/src/tokens/solana.tokenlist.json
+++ b/src/tokens/solana.tokenlist.json
@@ -130,7 +130,7 @@
       "symbol": "KSAMO",
       "name": "KING SAMO",
       "decimals": 6,
-      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/HDiA4quoMibAGeJQzvxajp3Z9cvnkNng99oVrnuNj6px/logo.svg",
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/HDiA4quoMibAGeJQzvxajp3Z9cvnkNng99oVrnuNj6px/logo.png",
       "tags": [
         "meme-token"
       ],

--- a/src/tokens/solana.tokenlist.json
+++ b/src/tokens/solana.tokenlist.json
@@ -984,7 +984,9 @@
       "extensions": {
         "twitter": "https://twitter.com/GoldSolDoge",
         "website": "https://http://www.goldsoldoge.com/"
-      },
+      }
+    },
+    {
       "chainId": 101,
       "address": "B7RDhZ2iqE4FEwK5nfcZ9r2xhVL6rQJCo1dcjDXnF688",
       "symbol": "LAT",

--- a/src/tokens/solana.tokenlist.json
+++ b/src/tokens/solana.tokenlist.json
@@ -23348,11 +23348,8 @@
     },
     {
       "chainId": 101,
-      "address": "F7mgxaYF1gg1hBtaVzENSG6ey3pn6J1mXhBRmHxDzBNg ",
       "address": "F7mgxaYF1gg1hBtaVzENSG6ey3pn6J1mXhBRmHxDzBNg",
-      "symbol": "SINU ",
       "symbol": "SINU",
-      "name": "Samo INU ",
       "name": "Samo INU",
       "decimals": 9,
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/F7mgxaYF1gg1hBtaVzENSG6ey3pn6J1mXhBRmHxDzBNg/logo.png",
@@ -23403,7 +23400,6 @@
     },
     {
       "chainId": 101,
-      "address": "2LxZrcJJhzcAju1FBHuGvw929EVkX7R7Q8yA2cdp8q7b ",
       "address": "2LxZrcJJhzcAju1FBHuGvw929EVkX7R7Q8yA2cdp8q7b",
       "symbol": "BORK",
       "name": "BORK",


### PR DESCRIPTION
Improvements split into 2 commits for clarity:
1. reformat whitespace only (no changes to dictionary structure) for consistency and clarity
2. move ~20 token definitions into the `tokens` list element (were mistakenly added one level too high starting with `BPCoin`)