### PR TITLE
Add schema and carefully clean up existing data

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,11 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: 12
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '^1.17.3'
+
       - run: yarn
       - run: yarn test
-      
+      - run: go install cuelang.org/go/cmd/cue@v0.4.0
+      - run: PATH=$PATH:~/go/bin cd src/tokens && ./validate.sh

--- a/src/tokens/schema.cue
+++ b/src/tokens/schema.cue
@@ -1,0 +1,177 @@
+package tokenlist
+
+// Solana-specific derivative of https://uniswap.org/tokenlist.schema.json,
+// converted to a CUE schema from JSON Schema.
+//
+// The current solana.tokenlist.json does not validate against the
+// Uniswap upstream schema! Deviations are marked INCOMPATIBLE.
+
+import (
+	"strings"
+	"list"
+	"struct"
+)
+
+#Base58Address: =~"^[1-9A-HJ-NP-Za-km-z]{43,44}$"
+
+#EthAddress: =~"^0x[0-9a-fA-F]{40}$"
+
+// Grandfathered non-compliant symbol names.
+#SymbolWhitelist: ("GÜ" |
+	"W technology" |
+	"weFTX Token" |
+	"SHBL LP token" |
+	"Unlimited Energy" |
+	"Need for Speed" |
+	"ADOR OPENS" |
+	"CMS - Rare" |
+	"Power User" |
+	"VIP Member" |
+	"Uni Christmas" |
+	"Satoshi Closeup" |
+	"Satoshi GB" |
+	"Satoshi OG" |
+	"Satoshi BTC" |
+	"APESZN_HOODIE" |
+	"APESZN_TEE_SHIRT" |
+	"Satoshi Closeup" |
+	"Satoshi BTC" |
+	"Satoshi Nakamoto" |
+	"Charles Hoskinson" |
+	"Bitcoin Tram" |
+	"SRM tee-shirt" |
+	"USDT_ILT" |
+	"NINJA NFT1" |
+	"USDC/USDT[stable]" |
+	"mSOL/SOL[stable]" |
+	"Nordic Energy Token" |
+	"USDC-wUSDC-wUSDT-wDAI" )
+
+// Grandfathered non-compliant token names.
+#NameWhitelist: (
+		"Mike Krow's Official Best Friend Super Kawaii Kasu Token" | "B ❤ P")
+
+// INCOMPATIBLE: may contain -
+// INCOMPATIBLE: max 20 characters (vs. 10)
+#TagIdentifier: strings.MinRunes(1) & strings.MaxRunes(20) & =~"^[\\w-]+$"
+
+#TagDefinition: {
+	// The name of the tag
+	// INCOMPATIBLE: may contain -
+	name: =~"^[ \\w-]+$" & strings.MinRunes(1) & strings.MaxRunes(20)
+
+	// A user-friendly description of the tag
+	// INCOMPATIBLE: may contain -
+	description: =~"^[ \\w\\.,:-]+$" & strings.MinRunes(1) & strings.MaxRunes(200)
+}
+
+#Version: {
+	// The major version of the list. Must be incremented when tokens
+	// are removed from the list or token addresses are changed.
+	major: int & >=0
+
+	// The minor version of the list. Must be incremented when tokens
+	// are added to the list.
+	minor: int & >=0
+
+	// The patch version of the list. Must be incremented for any
+	// changes to the list.
+	patch: int & >=0
+}
+
+#URL: =~ #"^(ipfs|http[s]?)://(?:[a-zA-Z]|[0-9]|[$-_@.&+#~]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+$"#
+#TelegramURL: =~ #"^https://t.me/((\w){5,32}|joinchat/[\w-]{16})$"#
+
+#Extensions: {
+	website?: #URL
+	twitter?: =~ #"^https://twitter.com/(\w){1,15}$"#
+	telegram?: #TelegramURL
+	telegramAnnouncements?: #TelegramURL
+	serumV3Usdc?: #Base58Address
+	serumV3Usdt?: #Base58Address
+	coingeckoId?: =~ #"^[\w-]+$"#
+	address?: #Base58Address | #EthAddress | "uusd" | "uluna"
+	bridgeContract?: #URL
+	assetContract?: #URL
+	discord?: #URL
+	medium?: #URL
+	instagram?: #URL
+	reddit?: #URL
+	coinmarketcap?: #URL
+	facebook?: #URL
+	github?: #URL
+	youtube?: #URL
+	waterfallbot?: #URL
+	dexWebsite?: #URL
+	imageUrl?: #URL
+	animationUrl?: #URL
+	linkedin?: #URL
+	description?: string & strings.MinRunes(1) & strings.MaxRunes(2000)
+	blog?: #URL
+	vault?: #URL
+	whitepaper?: #URL
+	twitch?: #URL
+	solanium?: #URL
+	vaultPubkey?: #Base58Address
+	attributes?: _
+}
+
+#TokenInfo: {
+	// The chain ID of the Solana network where this token is
+	// deployed.
+	chainId: 101 | 102 | 103
+
+	// The checksummed address of the token on the specified chain ID
+	// INCOMPATIBLE: base58
+	address: #Base58Address
+
+	// The number of decimals for the token balance
+	decimals: int & >=0 & <=255
+
+	// The name of the token
+	name: strings.MinRunes(1) & strings.MaxRunes(50) & =~"^[ \\w.'+\\-%/À-ÖØ-öø-ÿ:&\\[\\]\\(\\)]+$" | #NameWhitelist
+
+	// The symbol for the token; must be alphanumeric
+	symbol: =~"^[a-zA-Z0-9+\\-%/$.]+$" & strings.MinRunes(1) & strings.MaxRunes(20) | #SymbolWhitelist
+
+	// A URI to the token logo asset; if not set, interface will
+	// attempt to find a logo based on the token address; suggest SVG
+	// or PNG of size 64x64
+	logoURI?: #URL | ""
+
+	// An array of tag identifiers associated with the token; tags are
+	// defined at the list level
+	tags?:       list.MaxItems(10) & [...#TagIdentifier]
+
+	extensions?: #Extensions
+}
+
+#Tokenlist: {
+	// The name of the token list
+	name: strings.MinRunes(2) & strings.MaxRunes(20)
+
+	// The timestamp of this list version; i.e. when this immutable
+	// version of the list was created
+	timestamp: string
+	version:   #Version
+
+	// The list of tokens included in the list
+	tokens: list.MaxItems(10000) & [...#TokenInfo] & [_, ...]
+
+	// Keywords associated with the contents of the list; may be used
+	// in list discoverability.
+	//
+	// INCOMPATIBLE: keywords can contain -
+	keywords?: list.UniqueItems() & list.MaxItems(20) & [...strings.MinRunes(1) & strings.MaxRunes(20) & =~"^[\\w -]+$"]
+
+	// A mapping of tag identifiers to their name and description
+	tags?: struct.MaxFields(20) & {
+		[#TagIdentifier]: _
+	} & {
+		[string]: #TagDefinition
+	}
+
+	// A URI for the logo of the token list; prefer SVG or PNG of size
+	// 256x256
+	logoURI?: string
+}

--- a/src/tokens/solana.tokenlist.json
+++ b/src/tokens/solana.tokenlist.json
@@ -202,7 +202,7 @@
       ],
       "extensions": {
         "serumV3Usdc": "4k4WXdmrWjCG71E4pxMs6SQRRB5cypGNYatKb2iMnqN4",
-        "website": "http:/www.otterfinance.site",
+        "website": "http://www.otterfinance.site",
         "twitter": "https://twitter.com/otter_finance",
         "discord": "https://discord.gg/chfgc9wxnw"
       }
@@ -329,13 +329,13 @@
       "decimals": 2,
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/6bLp99VoqKU1C3Qp6VTNvSoCoc78jMGxPkGSSopq8wHB/logo.png",
       "tags": [
-        "meme coin",
+        "meme-token",
         "community",
         "doge",
         "Paws"
       ],
       "extensions": {
-        "website": " https://www.solpaws.com",
+        "website": "https://www.solpaws.com",
         "twitter": "https://twitter.com/Sol_Paws",
         "discord": "https://discord.gg/sVP35wfPhX"
       }
@@ -395,7 +395,7 @@
       "tags": [
         "community-token",
         "viking-token",
-        "viking floki",
+        "viking-floki",
         "nfts"
       ],
       "extensions": {}
@@ -410,7 +410,7 @@
       "tags": [
         "community-token",
         "meta-token",
-        "meta mark",
+        "meta-mark",
         "nfts"
       ],
       "extensions": {}
@@ -618,9 +618,7 @@
         "community-token",
         "meme-token",
         "doge",
-        "dogecoin",
-        "shiba inu",
-        "Golden Doge"
+        "dogecoin"
       ],
       "extensions": {
         "twitter": "https://twitter.com/GoldSolDoge",
@@ -670,7 +668,7 @@
       "tags": [],
       "extensions": {
         "website": "https://royalpangolins.io/",
-        "Discord": "https://discord.gg/XvjxsRzK",
+        "discord": "https://discord.gg/XvjxsRzK",
         "twitter": "https://twitter.com/RoyalPangolins"
       }
     },
@@ -685,9 +683,7 @@
         "community-token",
         "meme-token",
         "doge",
-        "dogecoin",
-        "shiba inu",
-        "Golden Doge"
+        "dogecoin"
       ],
       "extensions": {
         "twitter": "https://twitter.com/GoldSolDoge",
@@ -773,7 +769,7 @@
       "symbol": "$ASS",
       "name": "Ass Coin",
       "decimals": 9,
-      "logoUri": "https://static-api-cuazlhxxrq-uk.a.run.app/static/token.png",
+      "logoURI": "https://static-api-cuazlhxxrq-uk.a.run.app/static/token.png",
       "tags": [
         "MEMES-TOKEN",
         "NFTS",
@@ -831,11 +827,8 @@
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/p31qJ7LDLNRC57rU5GsXxFGBsnXheFXSsEn3avPoKDc/logo.png",
       "tags": [
         "nft",
-        "nft marketplace",
-        "artchive nft marketplace",
-        "artchive nft",
-        "governance token",
-        "governance coin"
+        "nft-marketplace",
+        "governance-token"
       ],
       "extensions": {
         "website": "https://artchivecoins.com/",
@@ -1028,7 +1021,7 @@
       "chainId": 101,
       "address": "GaAzf7jwEKTouDXJExH9TKfvX3Ae7fLaGwNuEajq7KsE",
       "symbol": "BARK",
-      "name": "Bark! o' Finance",
+      "name": "Bark o Finance",
       "decimals": 1,
       "logoURI": "https://i.imgur.com/X90vi6d.png",
       "tags": [
@@ -1116,7 +1109,7 @@
         "utility-token"
       ],
       "extensions": {
-        "website": " https://www.japantravel.me"
+        "website": "https://www.japantravel.me"
       }
     },
     {
@@ -1180,14 +1173,12 @@
         "meme-token",
         "doge",
         "dogecoin",
-        "shiba inu",
         "solcum",
         "monkey",
         "woof",
         "soldoge",
         "samo",
-        "smb",
-        "thugbirdz"
+        "smb"
       ],
       "extensions": {
         "coingeckoId": "wipemyass",
@@ -1237,8 +1228,7 @@
       "decimals": 9,
       "logoURI": "https://raw.githubusercontent.com/SolaToken/token-list/ninja/assets/mainnet/Hj4sTP4L4rvR9WBR6KyK99sxPptBQQczNWe4y15mxhRD/logo.png",
       "tags": [
-        "Solana tokenized",
-        "Solana Community token"
+        "community-token"
       ],
       "extensions": {
         "website": "https://solatoken.net/",
@@ -1258,13 +1248,12 @@
         "GameFi",
         "DeFi",
         "MetaVerse",
-        "stablecoin",
-        "Blockchain Game"
+        "stablecoin"
       ],
       "extensions": {
-        "website": "https://gta.live/",
-        "discord": "https://discord.gta.live/",
-        "telegram": "https://t.me/gta_fiverp/"
+        "website": "https://gta.live",
+        "discord": "https://discord.gta.live",
+        "telegram": "https://t.me/gta_fiverp"
       }
     },
     {
@@ -1278,13 +1267,12 @@
         "GameFi",
         "DeFi",
         "MetaVerse",
-        "stablecoin",
-        "Blockchain Game"
+        "stablecoin"
       ],
       "extensions": {
-        "website": "https://gta.live/",
-        "discord": "https://discord.gta.live/",
-        "telegram": "https://t.me/gta_fiverp/"
+        "website": "https://gta.live",
+        "discord": "https://discord.gta.live",
+        "telegram": "https://t.me/gta_fiverp"
       }
     },
     {
@@ -1325,7 +1313,7 @@
       "decimals": 9,
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/6Vg88xUHUPU9MfddHpu2cgx6CdodReiU8eGLPJgyhyVZ/logo.png",
       "tags": [
-        "token games",
+        "token-games",
         "nft-token"
       ],
       "extensions": {
@@ -1392,7 +1380,7 @@
         "coingeckoId": "almond",
         "coinmarketcap": "https://coinmarketcap.com/currencies/almond/",
         "website": "https://almond.so/",
-        "twitter": " https://twitter.com/almond_so",
+        "twitter": "https://twitter.com/almond_so",
         "discord": "https://discord.gg/MBWsChEdFw",
         "serumV3Usdc": "DNxn3qM61GZddidjrzc95398SCWhm5BUyt8Y8SdKYr8W"
       }
@@ -1425,7 +1413,7 @@
       "extensions": {
         "website": "https://unclemurphycoin.org/",
         "twitter": "https://twitter.com/Driver29973042",
-        "telegram channel": "https://t.me/joinchat/1x2i0txLEOY2Yjgy"
+        "telegram": "https://t.me/joinchat/1x2i0txLEOY2Yjgy"
       }
     },
     {
@@ -1470,7 +1458,7 @@
       "tags": [],
       "extensions": {
         "website": "https://swoledogecoin.org",
-        "discord": "discord.gg/HfdHnhQkpB",
+        "discord": "https://discord.gg/HfdHnhQkpB",
         "coingeckoId": "swole-doge",
         "serumV3Usdc": "3SGeuz8EXsyFo4HHWXQsoo8r4r5RdZkt7TuuTZiVbKc8",
         "twitter": "https://twitter.com/swoledoge"
@@ -1494,11 +1482,7 @@
       "symbol": "BNN",
       "name": "Banana",
       "decimals": 9,
-      "logoURI": "https://cdn.jsdelivr.net/gh/tradeape/First_token_image/bnn.png",
-      "tags": [],
-      "extensions": {
-        "website": ""
-      }
+      "logoURI": "https://cdn.jsdelivr.net/gh/tradeape/First_token_image/bnn.png"
     },
     {
       "chainId": 101,
@@ -1519,10 +1503,7 @@
       "name": "Picasso Token Div Test",
       "decimals": 9,
       "logoURI": "https://raw.githubusercontent.com/solfinaprotocol/token-list/main/assets/mainnet/9Sbzj4DnRW8qFnfvJWwXxQMRkWKAwHLs9NgDuBFjkVgW/logo.png",
-      "tags": [],
-      "extensions": {
-        "website": ""
-      }
+      "tags": []
     },
     {
       "chainId": 101,
@@ -1646,10 +1627,7 @@
       "name": "SOLFI",
       "decimals": 9,
       "logoURI": "https://raw.githubusercontent.com/solfinaprotocol/token-list/main/assets/mainnet/3CaBxqxWsP5oqS84Pkja4wLxyZYsHzMivQbnfwFJQeL1/logo.png",
-      "tags": [
-        "Solana AMM",
-        "AMM Defi Exchange"
-      ],
+      "tags": [],
       "extensions": {
         "website": "https://solfina.io/",
         "twitter": "https://twitter.com/solfina_io"
@@ -1668,7 +1646,6 @@
       "extensions": {
         "website": "https://bitsol.finance",
         "telegram": "https://t.me/bitsolfinance",
-        "telegram channel": "https://t.me/bitsolana",
         "twitter": "https://twitter.com/bitsol_finance"
       }
     },
@@ -1722,7 +1699,6 @@
       "decimals": 9,
       "logoURI": "https://raw.githubusercontent.com/solexfin/token-list/main/assets/mainnet/AASdD9rAefJ4PP7iM89MYUsQEyCQwvBofhceZUGDh5HZ/logo.png",
       "tags": [
-        "Solana Defi",
         "Exchange",
         "DApp"
       ],
@@ -1756,14 +1732,9 @@
       "decimals": 5,
       "logoURI": "https://www.pnglib.com/wp-content/uploads/2021/02/letter-z_60235255a2bf7.png",
       "tags": [
-        "Solana Defi",
         "Exchange",
         "DApp"
-      ],
-      "extensions": {
-        "website": "https://",
-        "twitter": "https://"
-      }
+      ]
     },
     {
       "chainId": 101,
@@ -1791,8 +1762,7 @@
       "logoURI": "https://raw.githubusercontent.com/rishkumaria/bamboo/main/bamboo.png",
       "tags": [],
       "extensions": {
-        "coingeckoId": "bamboo-coin",
-        "website": " "
+        "coingeckoId": "bamboo-coin"
       }
     },
     {
@@ -1814,7 +1784,7 @@
       "chainId": 101,
       "address": "C8QMoDwQADoW4MVkDZx7HgnebeugnNXWztrqpcCT2mFj",
       "symbol": "SHARK",
-      "name": "Rogue Shark #129",
+      "name": "Rogue Shark 129",
       "decimals": 0,
       "logoURI": "https://raw.githubusercontent.com/L0px1n/token-list/main/assets/mainnet/shark.jpeg",
       "tags": [
@@ -1827,7 +1797,7 @@
       "chainId": 101,
       "address": "4oyPeSSUwfxExjBU76fTfAFHHrZ3HVwCHWqAUdpeFg6h",
       "symbol": "SHARK",
-      "name": "Rogue Shark #129",
+      "name": "Rogue Shark 129",
       "decimals": 0,
       "logoURI": "https://raw.githubusercontent.com/L0px1n/token-list/main/assets/mainnet/shark.jpeg"
     },
@@ -1867,10 +1837,7 @@
       "name": "Solum",
       "decimals": 9,
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/9XtRZwKzDXEJ61A7qCqbPz8jXMYHGT3LwxqrEzB6fqxv/logo.png",
-      "tags": [
-        "Solum DeFi",
-        "Solum Token"
-      ],
+      "tags": [],
       "extensions": {
         "website": "https://solum.finance/",
         "telegram": "https://t.me/solumfinance",
@@ -2099,8 +2066,7 @@
       "decimals": 9,
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/FYfQ9uaRaYvRiaEGUmct45F9WKam3BYXArTrotnTNFXF/logo.png",
       "tags": [
-        "Solana tokenized",
-        "Solana Community token"
+        "community-token"
       ],
       "extensions": {
         "website": "https://solatoken.net/",
@@ -2854,10 +2820,7 @@
       "name": "CHTST",
       "decimals": 9,
       "logoURI": "",
-      "tags": [],
-      "extensions": {
-        "website": ""
-      }
+      "tags": []
     },
     {
       "chainId": 101,
@@ -2878,11 +2841,7 @@
       "name": "Elemento6",
       "decimals": 9,
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/C4kmKzQ8o6NAP8pToERJF6C7V4PjCVE3o2oSrp24f5GP/logo.png",
-      "tags": [
-        "Elemento6",
-        "Carbon Emission Reduction Credit",
-        "Respectful Development Foundation"
-      ],
+      "tags": [],
       "extensions": {
         "website": "https://respectfuldevelopmentpanama.com"
       }
@@ -2909,8 +2868,8 @@
       "decimals": 6,
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/iVNcrNE9BRZBC9Aqf753iZiZfbszeAVUoikgT9yvr2a/logo.png",
       "tags": [
-        "DeFi",
-        "Fund Management"
+        "defi",
+        "fund-management"
       ],
       "extensions": {
         "website": "https://www.investin.pro/",
@@ -3454,7 +3413,6 @@
       ],
       "extensions": {
         "website": "https://upbots.com/",
-        "explorer": "https://etherscan.io/address/0xeae57ce9cc1984f202e15e038b964bb8bdf7229a",
         "serumV3Usdc": "2wr3Ab29KNwGhtzr5HaPCyfU1qGJzTUAN4amCLZWaD1H",
         "serumV3Usdt": "F1T7b6pnR8Pge3qmfNUfW6ZipRDiGpMww6TKTrRU4NiL",
         "coingeckoId": "upbots"
@@ -3788,7 +3746,7 @@
       ],
       "extensions": {
         "website": "https://www.primebech.app",
-        "twitter": "https://www.twitter.com/doesitxz"
+        "twitter": "https://twitter.com/doesitxz"
       }
     },
     {
@@ -6820,7 +6778,7 @@
       "chainId": 101,
       "address": "CCAQZHBVWKDukT68PZ3LenDs7apibeSYeJ3jHE8NzBC5",
       "symbol": "wPOOLZ",
-      "name": "$Poolz Finance (Wormhole)",
+      "name": "Poolz Finance (Wormhole)",
       "decimals": 9,
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/CCAQZHBVWKDukT68PZ3LenDs7apibeSYeJ3jHE8NzBC5/logo.png",
       "tags": [
@@ -7062,8 +7020,7 @@
         "twitter": "https://twitter.com/gopartyparrot",
         "telegram": "https://t.me/gopartyparrot",
         "medium": "https://gopartyparrot.medium.com/",
-        "discord": "https://discord.gg/gopartyparrot",
-        "comment": ""
+        "discord": "https://discord.gg/gopartyparrot"
       },
       "tags": []
     },
@@ -9920,10 +9877,10 @@
       ],
       "extensions": {
         "website": "https://sollock.org/",
-        "twitter": "https://twitter.com/@SOLLockOfficial",
+        "twitter": "https://twitter.com/SOLLockOfficial",
         "github": "https://github.com/SOLLock",
-        "tgann": "https://t.me/SOLLockAnn",
-        "tggroup": "https://t.me/SOLLock"
+        "telegramAnnouncements": "https://t.me/SOLLockAnn",
+        "telegram": "https://t.me/SOLLock"
       }
     },
     {
@@ -10027,23 +9984,9 @@
       "decimals": 9,
       "logoURI": "https://solareum.app/icons/XSB-G.png",
       "tags": [
-        "Web 3.0",
-        "SPL Wallet",
-        "Solana tokenized",
-        "Solana Community token"
+        "community-token"
       ],
       "extensions": {
-        "website": "https://solareum.app",
-        "telegram": "https://t.me/solareum_wallet",
-        "twitter": "https://twitter.com/solareum_wallet"
-      },
-      "extensions-ignore": {
-        "coingeckoId": "star-atlas",
-        "website": "https://solareum.app",
-        "telegram": "https://t.me/solareum_wallet",
-        "twitter": "https://twitter.com/solareum_wallet"
-      },
-      "extensions-old": {
         "website": "https://solareum.app",
         "telegram": "https://t.me/solareum_wallet",
         "twitter": "https://twitter.com/solareum_wallet"
@@ -10175,11 +10118,7 @@
       "name": "SOL stake pool",
       "decimals": 9,
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/2rg5syU3DSwwWs778FQ6yczDKhS14NM3vP4hqnkJ2jsM/logo.png",
-      "tags": [],
-      "extensions": {
-        "website": "https://solana.com/",
-        "background": "https://solana.com/static/8c151e179d2d7e80255bdae6563209f2/6833b/validators.webp"
-      }
+      "tags": []
     },
     {
       "chainId": 103,
@@ -10240,7 +10179,6 @@
       ],
       "extensions": {
         "website": "https://sushi.com",
-        "background": "https://sushi.com/static/media/Background-sm.fd449814.jpg/",
         "address": "0x6B3595068778DD592e39A122f4f5a5cF09C90fE2",
         "bridgeContract": "https://etherscan.io/address/0xf92cD566Ea4864356C5491c177A430C222d7e678",
         "assetContract": "https://etherscan.io/address/0x6B3595068778DD592e39A122f4f5a5cF09C90fE2",
@@ -10333,9 +10271,7 @@
       "name": "LOVE",
       "decimals": 6,
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/97qAF7ZKEdPdQaUkhASGA59Jpa2Wi7QqVmnFdEuPqEDc/logo.png",
-      "tags": [
-        "Diamond Love"
-      ],
+      "tags": [],
       "extensions": {
         "website": "https://diamondlove.io/",
         "telegram": "https://t.me/DiamondLoveX"
@@ -10485,7 +10421,6 @@
       "name": "Star Atlas",
       "decimals": 8,
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/ATLASXmbPQxBUYbxPsV97usA3fPQYEqzQBUHgiFCUsXx/logo.png",
-      "waterfallbot": "https://bit.ly/ATLASwaterfall",
       "tags": [
         "utility-token"
       ],
@@ -10493,6 +10428,7 @@
         "website": "https://staratlas.com",
         "description": "Star Atlas Token",
         "coingeckoId": "star-atlas",
+        "waterfallbot": "https://bit.ly/ATLASwaterfall",
         "serumV3Usdc": "Di66GTLsV64JgCCYGVcY21RZ173BHkjJVgPyezNN7P1K"
       }
     },
@@ -10503,7 +10439,6 @@
       "name": "Star Atlas DAO",
       "decimals": 8,
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/poLisWXnNRwC6oBu1vHiuKQzFjGL4XDSu4g9qjz9qVk/logo.png",
-      "waterfallbot": "https://bit.ly/POLISwaterfall",
       "tags": [
         "utility-token"
       ],
@@ -10511,7 +10446,8 @@
         "website": "https://staratlas.com",
         "description": "Star Atlas DAO Token",
         "coingeckoId": "star-atlas-dao",
-        "serumV3Usdc": "HxFLKUAmAMLz1jtT3hbvCMELwH5H9tpM2QugP8sKyfhW"
+        "serumV3Usdc": "HxFLKUAmAMLz1jtT3hbvCMELwH5H9tpM2QugP8sKyfhW",
+        "waterfallbot": "https://bit.ly/POLISwaterfall"
       }
     },
     {
@@ -10707,7 +10643,7 @@
       "tags": [
         "nft",
         "swap",
-        "nft marketplace"
+        "nft-marketplace"
       ],
       "extensions": {
         "website": "https://coffeemaker.finance"
@@ -10799,9 +10735,9 @@
       "decimals": 6,
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/DQRNdQWz5NzbYgknGsZqSSXbdhQWvXSe8S56mrtNAs1b/logo.png",
       "tags": [
-        "Cryptography",
-        "Blockchain security",
-        "Randomness and entropy"
+        "cryptography",
+        "blockchain-security",
+        "randomness-entropy"
       ],
       "extensions": {
         "website": "https://www.entroppp.com"
@@ -10938,11 +10874,10 @@
       "decimals": 2,
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/Hjc6Ku7VpMD8TqPUuimDXWvT3RWpnbm1viaUe3dUco3L/logo.png",
       "tags": [
-        "Payment Token",
-        "Social Token"
+        "payment-token",
+        "social-token"
       ],
       "extensions": {
-        "website": "all4free.crypto",
         "medium": "https://medium.com/@all4free.crypto"
       }
     },
@@ -11227,10 +11162,10 @@
       "extensions": {
         "serumV3Usdc": "9MZKfgZzPgeidAukYpHtsLYm4eAdJFnR7nhPosWT8jiv",
         "coingeckoId": "lotto",
-        "website": "lotto.finance",
+        "website": "https://lotto.finance",
         "address": "0xb0dfd28d3cf7a5897c694904ace292539242f858",
         "assetContract": "https://etherscan.io/address/0xb0dfd28d3cf7a5897c694904ace292539242f858",
-        "tggroup": "https://t.me/lottofinance"
+        "telegram": "https://t.me/lottofinance"
       }
     },
     {
@@ -11350,8 +11285,8 @@
         "website": "https://www.solpad.finance/",
         "twitter": "https://twitter.com/FinanceSolpad",
         "github": "https://github.com/solpad-finance",
-        "tgann": "https://t.me/solpadfinance",
-        "tggroup": "https://t.me/solpadfinance_chat"
+        "telegramAnnouncements": "https://t.me/solpadfinance",
+        "telegram": "https://t.me/solpadfinance_chat"
       }
     },
     {
@@ -11464,7 +11399,7 @@
       "logoURI": "https://raw.githubusercontent.com/sol-farm/token-logos/main/tulip.png",
       "tags": [
         "tulip",
-        "tulip protocol",
+        "tulip-protocol",
         "vaults"
       ],
       "extensions": {
@@ -11575,7 +11510,7 @@
         "website": "https://kekw.io/",
         "twitter": "https://twitter.com/kekwcoin",
         "medium": "https://kekwcoin.medium.com/",
-        "discord": "discord.gg/kekw",
+        "discord": "https://discord.gg/kekw",
         "description": "Kekwcoin is a creative community platform for content creators to monetize their artwork and get financial support from investors.",
         "serumV3Usdc": "N99ngemA29qSKqdDW7kRiZHS7h2wEFpdgRvgE3N2jy6"
       }
@@ -11651,7 +11586,7 @@
       "extensions": {
         "website": "https://www.mememarket.place",
         "twitter": "https://twitter.com/MemeMarketNFT",
-        "discord": "http://discord.gg/mememarketplace"
+        "discord": "https://discord.gg/mememarketplace"
       }
     },
     {
@@ -11674,11 +11609,7 @@
       "name": "Sproken Token",
       "decimals": 9,
       "logoURI": "https://cdn.jsdelivr.net/gh/kechricc/Sproken-Token-Logo/SprokenToken.png",
-      "tags": [
-        "Sprocket Token",
-        "Mini Aussie",
-        "Currency of the Sprokonomy"
-      ],
+      "tags": [],
       "extensions": {
         "website": "https://www.sprokentoken.com/"
       }
@@ -11707,7 +11638,7 @@
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/H5gczCNbrtso6BqGKihF97RaWaxpUEZnFuFUKK4YX3s2/logo.png",
       "tags": [],
       "extensions": {
-        "website": "bigdefienergy.com",
+        "website": "https://bigdefienergy.com",
         "twitter": "https://twitter.com/Bigdefi"
       }
     },
@@ -11854,8 +11785,8 @@
       "extensions": {
         "website": "https://fuckelonmusk.godaddysites.com/",
         "twitter": "https://twitter.com/FuckElonMusk8",
-        "tgann": "https://t.me/fuckelonmusktoday",
-        "tggroup": "https://t.me/joinchat/cgUOCIRSTJ9hZmY1"
+        "telegramAnnouncements": "https://t.me/fuckelonmusktoday",
+        "telegram": "https://t.me/joinchat/cgUOCIRSTJ9hZmY1"
       }
     },
     {
@@ -11869,7 +11800,7 @@
       "extensions": {
         "website": "https://solanadon.com/",
         "twitter": "https://twitter.com/SolanadonCoin",
-        "tgann": "https://t.me/solanadonann"
+        "telegramAnnouncements": "https://t.me/solanadonann"
       }
     },
     {
@@ -12089,9 +12020,7 @@
       "decimals": 8,
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/APvgd1J98PGW77H1fDa7W7Y4fcbFwWfs71RNyJKuYs1Y/logo.png",
       "tags": [
-        "Fuzzy.One",
-        "FUZ",
-        "Supply chain token"
+        "supply-chain-token"
       ],
       "extensions": {
         "website": "https://www.fuzzy.one/"
@@ -12148,7 +12077,7 @@
       "tags": [],
       "extensions": {
         "website": "https://www.solempad.net/",
-        "twitter": "https://www.twitter.com/solempad",
+        "twitter": "https://twitter.com/solempad",
         "telegram": "https://t.me/solempad"
       }
     },
@@ -12353,7 +12282,7 @@
         "website": "https://apexit.finance/",
         "twitter": "https://twitter.com/apeXit_finance",
         "discord": "https://discord.gg/aASQy2dWsN",
-        "tggroup": "https://t.me/apexit_finance"
+        "telegram": "https://t.me/apexit_finance"
       }
     },
     {
@@ -12753,7 +12682,8 @@
       "decimals": 0,
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/BiJyWQr1Gpke3ouevgGCjtd9sSwSiUxdpnpGvJaoGQNL/logo.png",
       "tags": [
-        "utility-token, social-token"
+        "utility-token",
+        "social-token"
       ],
       "extensions": {
         "website": "https://www.solninja-go.art/",
@@ -14199,10 +14129,8 @@
       "decimals": 9,
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/E52bRrLGu1YFHBLNTWhdeGoYKyp1UYCTjB7XPoFgapYS/logo.png",
       "tags": [
-        "Sapling Network",
-        "SAPN",
         "sapling",
-        "ecofriendly token"
+        "ecofriendly-token"
       ],
       "extensions": {
         "website": "http://sapling.network",
@@ -14501,7 +14429,6 @@
       "decimals": 6,
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/FZgL5motNWEDEa24xgfSdBDfXkB9Ru9KxfEsey9S58bb/logo.svg",
       "tags": [
-        "venture capital",
         "liquidator",
         "IDO",
         "incubator"
@@ -14522,10 +14449,10 @@
         "utility-token"
       ],
       "extensions": {
-        "website": "https://www.oxbull.tech/#/home",
+        "website": "https://www.oxbull.tech",
         "twitter": "https://twitter.com/OxBull5",
         "medium": "https://medium.com/@oxbull",
-        "tgann": "https://t.me/Oxbull_tech",
+        "telegramAnnouncements": "https://t.me/Oxbull_tech",
         "coingeckoId": "oxbull-solana",
         "github": "https://github.com/OxBull"
       }
@@ -14689,7 +14616,7 @@
         "telegram": "https://t.me/SolHamster",
         "coingeckoId": "space-hamster",
         "coinmarketcap": "https://coinmarketcap.com/currencies/space-hamster/",
-        "dex-website": "https://dex-solhamster.space/"
+        "dexWebsite": "https://dex-solhamster.space/"
       }
     },
     {
@@ -14770,9 +14697,7 @@
       "decimals": 9,
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/D3gHoiYT4RY5VSndne1fEnpM3kCNAyBhkp5xjNUqqPj9/logo.png",
       "tags": [
-        "proof of-existence",
         "utility-token",
-        "prova de existencia",
         "proexis"
       ],
       "extensions": {
@@ -14781,8 +14706,8 @@
         "facebook": "https://facebook.com/provadeexistencia",
         "instagram": "https://instagram.com/provadeexistencia",
         "github": "https://github.com/provadeexistencia",
-        "tgann": "https://t.me/provadeexistencia",
-        "tggroup": "https://t.me/provadeexistenciagrupo"
+        "telegramAnnouncements": "https://t.me/provadeexistencia",
+        "telegram": "https://t.me/provadeexistenciagrupo"
       }
     },
     {
@@ -14851,9 +14776,7 @@
       "name": "Green DEX",
       "decimals": 9,
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/5fEo6ZbvpV6zdyzowtAwgMcWHZe1yJy9NxQM6gC19QW5/logo.svg",
-      "tags": [
-        "Green DEX"
-      ],
+      "tags": [],
       "extensions": {
         "website": "https://greendex.network/",
         "twitter": "https://twitter.com/GreendexN"
@@ -14938,7 +14861,7 @@
         "website": "https://DefiXBet.com/",
         "twitter": "https://twitter.com/DefiXBet",
         "medium": "https://defixbet.medium.com/",
-        "tgann": "https://t.me/DefiXBet"
+        "telegramAnnouncements": "https://t.me/DefiXBet"
       }
     },
     {
@@ -15336,15 +15259,11 @@
       "name": "PKR2",
       "decimals": 9,
       "logoURI": "https://raw.githubusercontent.com/C-e-r-b-e-r-u-s/token-list/main/assets/mainnet/A1C9Shy732BThWvHAN936f33N7Wm1HbFvxb2zDSoBx8F/pkr2-logo.png",
-      "tags": [
-        "https://www.pokerrrrapp.com/",
-        "Club Code: 03m91"
-      ],
+      "tags": [],
       "extensions": {
         "website": "https://twitter.com/PKR2_Token",
         "twitter": "https://twitter.com/PKR2_Token",
-        "serumV3Usdt": "AUYZV5BbKePrAkMiWCMhc1EbZCPNHDrK7Jf8jYy8noF6",
-        "description": "A new architecture for a high performance money powered by Solana."
+        "serumV3Usdt": "AUYZV5BbKePrAkMiWCMhc1EbZCPNHDrK7Jf8jYy8noF6"
       }
     },
     {
@@ -15569,8 +15488,8 @@
       "extensions": {
         "website": "https://solanacrayon.com",
         "twitter": "https://twitter.com/SolanaCrayon",
-        "serumV3Usdc": "CjBssusBjX4b2UBvMZhiZCQshW1afpQPA1Mv29Chn6vj",
-        "description": "Crayon is a meme token, Dex, and Dapps on Solana."
+        "description": "Crayon is a meme token, Dex, and Dapps on Solana.",
+        "serumV3Usdc": "CjBssusBjX4b2UBvMZhiZCQshW1afpQPA1Mv29Chn6vj"
       }
     },
     {
@@ -15585,9 +15504,9 @@
         "earnings"
       ],
       "extensions": {
+        "description": "Cryptor let people invest in crypto throught Twitch.",
         "twitter": "https://twitter.com/biiitor",
-        "twitch": "https://twitch.tv/bt0r",
-        "description": "Cryptor let people invest in crypto throught Twitch."
+        "twitch": "https://twitch.tv/bt0r"
       }
     },
     {
@@ -15599,7 +15518,7 @@
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/z9WZXekbCtwoxyfAwEJn1euXybvqLzPVv3NDzJzkq7C/logo.png",
       "tags": [],
       "extensions": {
-        "twitter": " https://twitter.com/carecointoken_",
+        "twitter": "https://twitter.com/carecointoken_",
         "website": "https://www.carecoin.site"
       }
     },
@@ -15624,9 +15543,7 @@
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/5U93vfnWJ4NKDhm7k1X7J6D15nJim2odivn9MmfCWwPU/logo.png",
       "tags": [
         "email-token",
-        "email-coin",
-        "CHUM",
-        "Chum Coin"
+        "email-coin"
       ],
       "extensions": {
         "website": "https://chumsmart.com"
@@ -15696,7 +15613,6 @@
       "symbol": "C98",
       "name": "Coin98",
       "decimals": 6,
-      "waterfallbot": "https://bit.ly/C98waterfall",
       "logoURI": "https://coin98.s3.ap-southeast-1.amazonaws.com/Coin/c98-512.svg",
       "tags": [
         "social-token"
@@ -15706,7 +15622,8 @@
         "twitter": "https://twitter.com/coin98_finance",
         "telegram": "https://t.me/coin98_finance",
         "github": "https://github.com/coin98",
-        "coingeckoId": "coin98"
+        "coingeckoId": "coin98",
+        "waterfallbot": "https://bit.ly/C98waterfall"
       }
     },
     {
@@ -15716,7 +15633,6 @@
       "name": "Saber Protocol Token",
       "decimals": 6,
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/Saber2gLauYim4Mvftnrasomsv6NvAuncvMEZwcLpD1/logo.svg",
-      "waterfallbot": "https://bit.ly/SBRwaterfall",
       "tags": [],
       "extensions": {
         "website": "https://saber.so",
@@ -15725,7 +15641,8 @@
         "medium": "https://blog.saber.so",
         "discord": "https://chat.saber.so",
         "serumV3Usdc": "HXBi8YBwbh4TXF6PjVw81m8Z3Cc4WBofvauj5SBFdgUs",
-        "coingeckoId": "saber"
+        "coingeckoId": "saber",
+        "waterfallbot": "https://bit.ly/SBRwaterfall"
       }
     },
     {
@@ -15765,10 +15682,7 @@
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/AWTE7toEwKdSRd7zh3q45SjKhmYVFp3zk4quWHsM92bj/logo.png",
       "tags": [
         "utility-token"
-      ],
-      "extensions": {
-        "website": "zaucoin.crypto"
-      }
+      ]
     },
     {
       "chainId": 101,
@@ -15923,7 +15837,7 @@
         "website": "https://hapi.one",
         "twitter": "https://twitter.com/i_am_hapi_one",
         "medium": "https://medium.com/i-am-hapi",
-        "telegram": "http://t.me/hapiHF",
+        "telegram": "https://t.me/hapiHF",
         "coingeckoId": "hapi",
         "github": "https://github.com/HAPIprotocol/HAPI/"
       }
@@ -15937,11 +15851,11 @@
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/Lrxqnh6ZHKbGy3dcrCED43nsoLkM1LTzU2jRfWe8qUC/logo.jpg",
       "tags": [],
       "extensions": {
-        "website": "projectlarix.com",
+        "website": "https://projectlarix.com",
         "twitter": "https://twitter.com/ProjectLarix",
-        "discord": "http://discord.gg/hfnRFV9Ngt",
+        "discord": "https://discord.gg/hfnRFV9Ngt",
         "medium": "http://projectlarix.medium.com",
-        "telegram": "http://t.me/projectlarix",
+        "telegram": "https://t.me/projectlarix",
         "coingeckoId": "larix",
         "github": "https://github.com/ProjectLarix/Larix-Lending-Project-Rep"
       }
@@ -16032,7 +15946,7 @@
         "twitter": "https://twitter.com/WeebFinance",
         "discord": "https://discord.gg/fzZbyXAzaG",
         "medium": "https://medium.com/@WeebFinance",
-        "telegram": "http://t.me/weeb_finance"
+        "telegram": "https://t.me/weeb_finance"
       }
     },
     {
@@ -16129,7 +16043,7 @@
         "website": "https://solbet.org/",
         "telegram": "https://t.me/solbet_official",
         "discord": "https://solbet.org/discord",
-        "twitter": "https://twitter.com/solbet_official/",
+        "twitter": "https://twitter.com/solbet_official",
         "serumV3Usdc": "GsWX1FgWP35jchi5R9uiNys2g6GftruEiHVpPS2b7Vq8",
         "description": "SOLBET seeks to facilitate P2P speculation and provide trustless on-chain escrow services for speculative ventures utilizing on-chain data, oracle services, and private data node operators to verify outcomes for all parties involved."
       }
@@ -16439,7 +16353,6 @@
       "name": "Port Finance Token",
       "decimals": 6,
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/PoRTjZMPXb9T7dyU7tpLEZRQj7e6ssfAE62j2oQuc6y/PORT.png",
-      "waterfallbot": "https://bit.ly/PORTwaterfall",
       "tags": [],
       "extensions": {
         "website": "https://port.finance/",
@@ -16449,6 +16362,7 @@
         "discord": "https://discord.gg/nAMXAYhTb2",
         "telegram": "https://t.me/port_finance",
         "serumV3Usdc": "8x8jf7ikJwgP9UthadtiGFgfFuyyyYPHL3obJAuxFWko",
+        "waterfallbot": "https://bit.ly/PORTwaterfall",
         "coingeckoId": "port-finance"
       }
     },
@@ -16668,9 +16582,7 @@
       "decimals": 6,
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/PRT88RkA4Kg5z7pKnezeNH4mafTvtQdfFgpQTGRjz44/logo.svg",
       "tags": [
-        "utility-token",
-        "POFA token",
-        "Meme-Token"
+        "utility-token"
       ],
       "extensions": {
         "website": "https://parrot.fi",
@@ -16749,7 +16661,6 @@
       "decimals": 6,
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/SUNNYWgPQmFxe9wTZzNK7iPnJ3vYDrkgnxJRJm1s3ag/logo.svg",
       "tags": [],
-      "waterfallbot": "https://bit.ly/SUNNYwaterfall",
       "extensions": {
         "website": "https://sunny.ag/",
         "twitter": "https://twitter.com/SunnyAggregator",
@@ -16757,6 +16668,7 @@
         "medium": "https://medium.com/sunny-aggregator",
         "discord": "https://chat.sunny.ag",
         "serumV3Usdc": "Aubv1QBFh4bwB2wbP1DaPW21YyQBLfgjg8L4PHTaPzRc",
+        "waterfallbot": "https://bit.ly/SUNNYwaterfall",
         "coingeckoId": "sunny-aggregator"
       }
     },
@@ -16775,7 +16687,6 @@
         "telegram": "https://t.me/cyclosofficialchat",
         "discord": "https://discord.gg/vpbTxzHWYg",
         "twitter": "https://twitter.com/cyclosfi",
-        "email": "contact@cyclos.io",
         "github": "https://github.com/cyclos-io",
         "coinmarketcap": "https://coinmarketcap.com/currencies/cyclos/",
         "solanium": "https://www.solanium.io/project/cyclos/",
@@ -16814,7 +16725,7 @@
       "tags": [],
       "extensions": {
         "website": "https://solana.lido.fi/",
-        "twitter": "https://twitter.com/LidoFinance/"
+        "twitter": "https://twitter.com/LidoFinance"
       }
     },
     {
@@ -16830,7 +16741,7 @@
       ],
       "extensions": {
         "website": "https://lido.fi/",
-        "twitter": "https://twitter.com/LidoFinance/",
+        "twitter": "https://twitter.com/LidoFinance",
         "telegram": "https://t.me/lidofinance",
         "discord": "https://discord.gg/WhhnWwsFXz",
         "github": "https://github.com/lidofinance",
@@ -16850,7 +16761,7 @@
       ],
       "extensions": {
         "website": "https://lido.fi/",
-        "twitter": "https://twitter.com/LidoFinance/",
+        "twitter": "https://twitter.com/LidoFinance",
         "telegram": "https://t.me/lidofinance",
         "discord": "https://discord.gg/WhhnWwsFXz",
         "github": "https://github.com/lidofinance"
@@ -17081,8 +16992,7 @@
       "extensions": {
         "website": "http://solcry.io/",
         "telegram": "https://t.me/sol_cry",
-        "discord": "http://discord.gg/ghnnPvQNgS",
-        "email": "contact@solcry.io",
+        "discord": "https://discord.gg/ghnnPvQNgS",
         "github": "https://github.com/sol-crystal",
         "medium": "https://solcrystal.medium.com/",
         "serumV3Usdc": "H3e7YziokpHJfFAMAy2PK6sNph72f38P1ELd5TUQaocv",
@@ -17154,7 +17064,6 @@
         "twitter": "https://twitter.com/SolAshera",
         "discord": "https://discord.gg/b3qYsNyBkz",
         "medium": "https://solashera.medium.com/",
-        "telegram": "https://twitter.com/SolAshera",
         "github": "https://github.com/asherasol"
       }
     },
@@ -17171,7 +17080,7 @@
       "extensions": {
         "website": "https://intersola.io/",
         "medium": "https://intersola.medium.com/",
-        "telegram": "https://t.me/intersola/",
+        "telegram": "https://t.me/intersola",
         "twitter": "https://twitter.com/intersola_io",
         "github": "https://github.com/Intersolaio/",
         "serumV3Usdt": "42QVcMqoXmHT94zaBXm9KeU7pqDfBuAPHYN9ADW8weCF"
@@ -17557,20 +17466,7 @@
       "name": "Qia Coin",
       "decimals": 9,
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/8SvvzDMu5jqcBhfdYZM1zDjDG5YGYrsNmGsPzTm4bFYU/logo.png",
-      "tags": [],
-      "extensions": {
-        "address": "3yN3xNcXxbhkZYC6MXak1f7Ff29BZdGyc4GUQ1jbyt27",
-        "symbol": "NOVA",
-        "name": "Nova frolic Sol Token",
-        "decimals": 9,
-        "logoURI": "https://cdn.jsdelivr.net/gh/sahityakumarsuman/frolic-token/nova_token.png",
-        "tags": [
-          "lp-token"
-        ],
-        "extensions": {
-          "website": "https://www.frolic.live/"
-        }
-      }
+      "tags": []
     },
     {
       "chainId": 101,
@@ -17648,8 +17544,8 @@
         "MEME"
       ],
       "extensions": {
-        "website": "https://www.cutiepatootie.tech/",
-        "twitter": "https://twitter.com/CutiePatotieSLN/",
+        "website": "https://www.cutiepatootie.tech",
+        "twitter": "https://twitter.com/CutiePatotieSLN",
         "discord": "https://discord.gg/2d3FvQUR",
         "github": "https://github.com/Cutie-Patootie-Token",
         "telegram": "https://t.me/joinchat/XFk1Boii0GxiNDc0"
@@ -17662,9 +17558,7 @@
       "name": "Seldom",
       "decimals": 6,
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/Hp5CJjw9YxJeo8mAgkyUomzKGPUxEwyo6gGt6hj56aTw/logo.png",
-      "tags": [
-        ""
-      ]
+      "tags": []
     },
     {
       "chainId": 101,
@@ -17777,8 +17671,8 @@
       ],
       "extensions": {
         "twitter": "https://twitter.com/Solanainfinity",
-        "discord": "http://discord.gg/z9st3dHRPf",
-        "telegram": "http://t.me/Solinfinity_official"
+        "discord": "https://discord.gg/z9st3dHRPf",
+        "telegram": "https://t.me/Solinfinity_official"
       }
     },
     {
@@ -17823,9 +17717,9 @@
         "stake-pool"
       ],
       "extensions": {
-        "discord": "https://discord.gg/k8ZcW27bq9/",
-        "medium": "https://medium.com/@soceanfinance/",
-        "twitter": "https://twitter.com/soceanfinance/",
+        "discord": "https://discord.gg/k8ZcW27bq9",
+        "medium": "https://medium.com/@soceanfinance",
+        "twitter": "https://twitter.com/soceanfinance",
         "website": "https://socean.fi/",
         "coingeckoId": "socean-staked-sol"
       }
@@ -17867,11 +17761,10 @@
       ],
       "extensions": {
         "website": "https://www.museinc.studio",
-        "PlayStore": "https://play.google.com/store/apps/details?id=com.mimshachstudios.muse",
         "twitter": "https://twitter.com/_museinc",
-        "Instagram": "https://www.instagram.com/_museinc/",
-        "Telegram": "https://t.me/kauritoken",
-        "Discord": "https://discord.gg/jeN7dhes9V"
+        "instagram": "https://www.instagram.com/_museinc/",
+        "telegram": "https://t.me/kauritoken",
+        "discord": "https://discord.gg/jeN7dhes9V"
       }
     },
     {
@@ -18019,9 +17912,7 @@
       "name": "PEPE Coin",
       "decimals": 9,
       "logoURI": "https://cdn.jsdelivr.net/gh/matthew-github-123/pepetoken/frog.png",
-      "tags": [
-        "SPL token"
-      ],
+      "tags": [],
       "extensions": {
         "twitter": "https://twitter.com/Pepe_Solana_SPL"
       }
@@ -18100,9 +17991,9 @@
       "decimals": 6,
       "logoURI": "https://raw.githubusercontent.com/sol-farm/token-logos/main/tuUSDC.png",
       "tags": [
-        "tulip protocol",
+        "tulip-protocol",
         "lending",
-        "collateral tokens"
+        "collateral-tokens"
       ],
       "extensions": {
         "website": "https://tulip.garden",
@@ -18118,9 +18009,9 @@
       "decimals": 6,
       "logoURI": "https://raw.githubusercontent.com/sol-farm/token-logos/main/tuTULIP.png",
       "tags": [
-        "tulip protocol",
+        "tulip-protocol",
         "lending",
-        "collateral tokens"
+        "collateral-tokens"
       ],
       "extensions": {
         "website": "https://tulip.garden",
@@ -18136,9 +18027,9 @@
       "decimals": 9,
       "logoURI": "https://raw.githubusercontent.com/sol-farm/token-logos/main/tuSOL.png",
       "tags": [
-        "tulip protocol",
+        "tulip-protocol",
         "lending",
-        "collateral tokens"
+        "collateral-tokens"
       ],
       "extensions": {
         "website": "https://tulip.garden",
@@ -18154,9 +18045,9 @@
       "decimals": 6,
       "logoURI": "https://raw.githubusercontent.com/sol-farm/token-logos/main/tuSNY.png",
       "tags": [
-        "tulip protocol",
+        "tulip-protocol",
         "lending",
-        "collateral tokens"
+        "collateral-tokens"
       ],
       "extensions": {
         "website": "https://tulip.garden",
@@ -18172,9 +18063,9 @@
       "decimals": 6,
       "logoURI": "https://raw.githubusercontent.com/sol-farm/token-logos/main/tuSLRS.png",
       "tags": [
-        "tulip protocol",
+        "tulip-protocol",
         "lending",
-        "collateral tokens"
+        "collateral-tokens"
       ],
       "extensions": {
         "website": "https://tulip.garden",
@@ -18190,9 +18081,9 @@
       "decimals": 6,
       "logoURI": "https://raw.githubusercontent.com/sol-farm/token-logos/main/tuRAY.png",
       "tags": [
-        "tulip protocol",
+        "tulip-protocol",
         "lending",
-        "collateral tokens"
+        "collateral-tokens"
       ],
       "extensions": {
         "website": "https://tulip.garden",
@@ -18208,9 +18099,9 @@
       "decimals": 8,
       "logoURI": "https://raw.githubusercontent.com/sol-farm/token-logos/main/tuPOLIS.png",
       "tags": [
-        "tulip protocol",
+        "tulip-protocol",
         "lending",
-        "collateral tokens"
+        "collateral-tokens"
       ],
       "extensions": {
         "website": "https://tulip.garden",
@@ -18226,9 +18117,9 @@
       "decimals": 6,
       "logoURI": "https://raw.githubusercontent.com/sol-farm/token-logos/main/tuMEDIA.png",
       "tags": [
-        "tulip protocol",
+        "tulip-protocol",
         "lending",
-        "collateral tokens"
+        "collateral-tokens"
       ],
       "extensions": {
         "website": "https://tulip.garden",
@@ -18244,9 +18135,9 @@
       "decimals": 9,
       "logoURI": "https://raw.githubusercontent.com/sol-farm/token-logos/main/tuLIKE.png",
       "tags": [
-        "tulip protocol",
+        "tulip-protocol",
         "lending",
-        "collateral tokens"
+        "collateral-tokens"
       ],
       "extensions": {
         "website": "https://tulip.garden",
@@ -18262,9 +18153,9 @@
       "decimals": 6,
       "logoURI": "https://raw.githubusercontent.com/sol-farm/token-logos/main/tuETH.png",
       "tags": [
-        "tulip protocol",
+        "tulip-protocol",
         "lending",
-        "collateral tokens"
+        "collateral-tokens"
       ],
       "extensions": {
         "website": "https://tulip.garden",
@@ -18280,9 +18171,9 @@
       "decimals": 6,
       "logoURI": "https://raw.githubusercontent.com/sol-farm/token-logos/main/tuCOPE.png",
       "tags": [
-        "tulip protocol",
+        "tulip-protocol",
         "lending",
-        "collateral tokens"
+        "collateral-tokens"
       ],
       "extensions": {
         "website": "https://tulip.garden",
@@ -18298,9 +18189,9 @@
       "decimals": 8,
       "logoURI": "https://raw.githubusercontent.com/sol-farm/token-logos/main/tuATLAS.png",
       "tags": [
-        "tulip protocol",
+        "tulip-protocol",
         "lending",
-        "collateral tokens"
+        "collateral-tokens"
       ],
       "extensions": {
         "website": "https://tulip.garden",
@@ -18316,9 +18207,9 @@
       "decimals": 6,
       "logoURI": "https://raw.githubusercontent.com/sol-farm/token-logos/main/tuALEPH.png",
       "tags": [
-        "tulip protocol",
+        "tulip-protocol",
         "lending",
-        "collateral tokens"
+        "collateral-tokens"
       ],
       "extensions": {
         "website": "https://tulip.garden",
@@ -18436,7 +18327,7 @@
       "tags": [
         "solend",
         "lending",
-        "collateral tokens"
+        "collateral-tokens"
       ],
       "extensions": {
         "website": "https://solend.fi"
@@ -18452,7 +18343,7 @@
       "tags": [
         "solend",
         "lending",
-        "collateral tokens"
+        "collateral-tokens"
       ],
       "extensions": {
         "website": "https://solend.fi"
@@ -18468,7 +18359,7 @@
       "tags": [
         "solend",
         "lending",
-        "collateral tokens"
+        "collateral-tokens"
       ],
       "extensions": {
         "website": "https://solend.fi"
@@ -18484,7 +18375,7 @@
       "tags": [
         "solend",
         "lending",
-        "collateral tokens"
+        "collateral-tokens"
       ],
       "extensions": {
         "website": "https://solend.fi"
@@ -18500,7 +18391,7 @@
       "tags": [
         "solend",
         "lending",
-        "collateral tokens"
+        "collateral-tokens"
       ],
       "extensions": {
         "website": "https://solend.fi"
@@ -18516,7 +18407,7 @@
       "tags": [
         "solend",
         "lending",
-        "collateral tokens"
+        "collateral-tokens"
       ],
       "extensions": {
         "website": "https://solend.fi"
@@ -18532,7 +18423,7 @@
       "tags": [
         "solend",
         "lending",
-        "collateral tokens"
+        "collateral-tokens"
       ],
       "extensions": {
         "website": "https://solend.fi"
@@ -18548,7 +18439,7 @@
       "tags": [
         "solend",
         "lending",
-        "collateral tokens"
+        "collateral-tokens"
       ],
       "extensions": {
         "website": "https://solend.fi"
@@ -18564,7 +18455,7 @@
       "tags": [
         "solend",
         "lending",
-        "collateral tokens"
+        "collateral-tokens"
       ],
       "extensions": {
         "website": "https://solend.fi"
@@ -18580,7 +18471,7 @@
       "tags": [
         "solend",
         "lending",
-        "collateral tokens"
+        "collateral-tokens"
       ],
       "extensions": {
         "website": "https://solend.fi"
@@ -18626,7 +18517,7 @@
       "tags": [],
       "extensions": {
         "website": "https://lido.fi/",
-        "twitter": "https://twitter.com/LidoFinance/"
+        "twitter": "https://twitter.com/LidoFinance"
       }
     },
     {
@@ -18666,11 +18557,7 @@
       "name": "WATTTON Exchange",
       "decimals": 9,
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/AKAwZaP91svXuYTe2gD5JVmUZteDFrT4G92rMtrF1Wb4/logo.png",
-      "tags": [
-        "WATTTON",
-        "WATTTON Exchange",
-        "WATTTON Exchange Token"
-      ],
+      "tags": [],
       "extensions": {
         "website": "https://wattton.org"
       }
@@ -18881,8 +18768,7 @@
       ],
       "extensions": {
         "website": "https://jackietoken.tk/",
-        "coinalpha": "9xkb4MSeD2WkJuio3EdGhEjNP5MuAp56scwKpiDNLtHc",
-        "twitter": "https://twitter.com/jackie_token/",
+        "twitter": "https://twitter.com/jackie_token",
         "facebook": "https://www.facebook.com/groups/jackiechanfanclubgroup",
         "telegram": "https://t.me/jackietoken"
       }
@@ -19170,7 +19056,7 @@
       ],
       "extensions": {
         "website": "https://www.blackfreelancer.com",
-        "twitter": "https://www.twitter.com/blackfreelancr",
+        "twitter": "https://twitter.com/blackfreelancr",
         "instagram": "https://www.instagram.com/blackfreelancer",
         "blog": "https://blog.blackfreelancer.com"
       }
@@ -19188,7 +19074,7 @@
       ],
       "extensions": {
         "website": "https://www.soltomm.com",
-        "twitter": "https://www.twitter.com/soltomm",
+        "twitter": "https://twitter.com/soltomm",
         "telegram": "https://t.me/soltomm",
         "medium": "https://soltomm.medium.com"
       }
@@ -19408,7 +19294,6 @@
         "telegram": "https://t.me/dogelana",
         "facebook": "https://facebook.com/dogelana",
         "coingeckoId": "dogelana",
-        "email": "info@dogelana.com",
         "coinmarketcap": "https://coinmarketcap.com/currencies/dogelana/"
       }
     },
@@ -19438,7 +19323,7 @@
       ],
       "extensions": {
         "twitter": "https://twitter.com/SalvadorUsd",
-        "Telegram": "https://t.me/salvadousd"
+        "telegram": "https://t.me/salvadousd"
       }
     },
     {
@@ -19650,7 +19535,7 @@
       "chainId": 101,
       "address": "FLhkrAUE3kjwQwZPvAqDTAXULTgBUgjcAVtyzvwkcNrJ",
       "symbol": "MBB",
-      "name": "Fraktionalized MBB #2793",
+      "name": "Fraktionalized MBB 2793",
       "decimals": 3,
       "logoURI": "https://www.arweave.net/0RPQq5Z_808sLjsjZ67__kFbQYdfQNaztLpBuDPKaEA?ext=png",
       "tags": [
@@ -19665,7 +19550,7 @@
       "chainId": 101,
       "address": "Hk7P7ufaHe92Dx2Cmz6rSHT8RFj362kLYwMxJ9X5d7eF",
       "symbol": "MBB",
-      "name": "Fraktionalized MBB #1007",
+      "name": "Fraktionalized MBB 1007",
       "decimals": 3,
       "logoURI": "https://www.arweave.net/piH41aGwPKOVs_idwQGU-wh278ZPNmJPpjchwt_gAEc?ext=png",
       "tags": [
@@ -19924,7 +19809,7 @@
       "extensions": {
         "website": "https://synergyland.world/",
         "twitter": "https://twitter.com/SolFox_official",
-        "telegram": "t.me/Solfox_Official"
+        "telegram": "https://t.me/Solfox_Official"
       }
     },
     {
@@ -19949,7 +19834,7 @@
       "decimals": 9,
       "logoURI": "https://cdn.jsdelivr.net/gh/umersurkhailas/spllogo/vbuck.png",
       "tags": [
-        "vera token"
+        "vera-token"
       ]
     },
     {
@@ -19960,7 +19845,7 @@
       "decimals": 8,
       "logoURI": "https://dl.dropboxusercontent.com/s/1h1kbyfwhf9m8t3/vera-logo.png?dl=0",
       "tags": [
-        "vera token"
+        "vera-token"
       ],
       "extensions": {
         "website": "http://veracurrency.com"
@@ -19974,7 +19859,7 @@
       "decimals": 8,
       "logoURI": "https://dl.dropboxusercontent.com/s/1h1kbyfwhf9m8t3/vera-logo.png?dl=0",
       "tags": [
-        "vera token"
+        "vera-token"
       ],
       "extensions": {
         "website": "http://veracurrency.com"
@@ -20286,7 +20171,6 @@
         "utility-token"
       ],
       "extensions": {
-        "website": "",
         "twitter": "https://twitter.com/wefinph",
         "discord": "https://discord.gg/AMmx7k6H"
       }
@@ -20313,7 +20197,7 @@
       "decimals": 9,
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/54s1cUvcF5CuMhomJ65A3PFn6RASixP3J96taku6w6PP/logo.png",
       "tags": [
-        "tokenized invitation card"
+        "tokenized-invitation"
       ],
       "extensions": {}
     },
@@ -20624,8 +20508,8 @@
       ],
       "extensions": {
         "website": "https://aurory.io",
-        "description": "Aurory Token"
-        ,"coingeckoId": "aurory"
+        "description": "Aurory Token",
+        "coingeckoId": "aurory"
       }
     },
     {
@@ -20700,17 +20584,17 @@
       "tags": [],
       "extensions": {
         "website": "https://holona.net",
-        "reddit": "https://www.reddit.com/u/HolonaNetwork?utm_medium=android_app&utm_source=share",
+        "reddit": "https://www.reddit.com/u/HolonaNetwork",
         "telegram": "https://t.me/joinchat/UFpWIQwYE-kwYzA0",
-        "twitter": "https://twitter.com/HolonaNetwork?t=Cs9brkLq2eT9FbLUB8AYOg&s=09",
-        "youtube ": "https://youtube.com/channel/UCSTEasbK8OSsvOk2NR6RmCQ"
+        "twitter": "https://twitter.com/HolonaNetwork",
+        "youtube": "https://youtube.com/channel/UCSTEasbK8OSsvOk2NR6RmCQ"
       }
     },
     {
       "chainId": 101,
       "address": "BpK8nx5ygQaaFHnJyQ96mZePRvh74woxCNRT7CkjY81T",
       "symbol": "ME",
-      "name": "ME, Tokenized",
+      "name": "ME Tokenized",
       "decimals": 9,
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/BpK8nx5ygQaaFHnJyQ96mZePRvh74woxCNRT7CkjY81T/logo.png",
       "tags": [],
@@ -20783,7 +20667,7 @@
       ],
       "extensions": {
         "website": "https://ircurrency.org/",
-        "discord ": "https://discord.gg/4cxWg5Jmxt"
+        "discord": "https://discord.gg/4cxWg5Jmxt"
       }
     },
     {
@@ -20978,10 +20862,7 @@
       "name": "SOLINU",
       "decimals": 9,
       "logoURI": "",
-      "tags": [],
-      "extensions": {
-        "website": ""
-      }
+      "tags": []
     },
     {
       "chainId": 101,
@@ -20990,10 +20871,7 @@
       "name": "Alexey Kulikov Token",
       "decimals": 9,
       "logoURI": "https://cdn.jsdelivr.net/gh/pobegov/ak-token/logo.png",
-      "tags": [],
-      "extensions": {
-        "website": ""
-      }
+      "tags": []
     },
     {
       "chainId": 101,
@@ -21003,7 +20881,7 @@
       "decimals": 9,
       "logoURI": "https://github.com/GAtuBAN/GPUT/blob/main/Gput.png",
       "tags": [
-        "lgame-fi token"
+        "lgame-fi-token"
       ],
       "extensions": {
         "discord": "https://discord.gg/kemp5JZZVc"
@@ -21976,8 +21854,7 @@
         "nft",
         "gift",
         "game-coin",
-        "gaming",
-        "Blockchain Game"
+        "gaming"
       ],
       "extensions": {
         "website": "https://solvikings.com/",
@@ -22010,10 +21887,7 @@
       "name": "Cage Fight Series Coin",
       "decimals": 8,
       "logoURI": "https://file.avant-iconic.com/cfstoken.png",
-      "tags": [
-        "cage fight series",
-        "ettl bros"
-      ],
+      "tags": [],
       "extensions": {
         "website": "https://coin.cage-fight-series.com",
         "description": "Official Cage Fight Series Coin"
@@ -22331,7 +22205,6 @@
       "decimals": 9,
       "logoURI": "https://raw.githubusercontent.com/solanadevv/token-list/main/assets/mainnet/4cTDXDzieiTk2qibwtXty8UzvXGZXfd92dK3SF2EuKuV/logo.png",
       "tags": [
-        "Doge Solana",
         "Doge"
       ],
       "extensions": {
@@ -22367,8 +22240,7 @@
       "tags": [
         "Pig",
         "Meme",
-        "Lad",
-        "Pig Lad"
+        "Lad"
       ],
       "extensions": {}
     },
@@ -22468,12 +22340,12 @@
       "decimals": 9,
       "logoURI": "https://raw.githubusercontent.com/GreenFailure/Floof/main/OkyT9kpz_400x400.png",
       "tags": [],
-      "coingeckoId": "floof",
-      "serumV3Usdc": "BxcuT1p8FK9cFak4Uuf5nmoAZ7nQGu7FerCMESGqxF7b",
       "extensions": {
-        "website": "www.floofsolana.com",
+        "website": "https://www.floofsolana.com",
         "twitter": "https://twitter.com/FLOOF_SOLANA",
-        "discord": "https://discord.gg/Gr5Z8DZ67X"
+        "discord": "https://discord.gg/Gr5Z8DZ67X",
+        "coingeckoId": "floof",
+        "serumV3Usdc": "BxcuT1p8FK9cFak4Uuf5nmoAZ7nQGu7FerCMESGqxF7b"
       }
     },
     {
@@ -22512,7 +22384,7 @@
       "tags": [
         "utility-token",
         "Validator",
-        "Columbus.inc"
+        "Columbus-inc"
       ]
     },
     {
@@ -22622,8 +22494,7 @@
         "community-token",
         "meme-token",
         "doge",
-        "dogecoin",
-        "kishu inu"
+        "dogecoin"
       ],
       "extensions": {
         "twitter": "https://twitter.com/ShibamoonNFT",
@@ -22640,8 +22511,7 @@
       "tags": [
         "community-token",
         "utility-token",
-        "capys",
-        "ponque coin"
+        "capys"
       ],
       "extensions": {
         "twitter": "https://twitter.com/solcapys",
@@ -22656,9 +22526,7 @@
       "decimals": 8,
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/cqNTpypmbwghrf1G9VGvSENcw7M7wGSQ7JS8UTQWXwb/logo.png",
       "tags": [
-        "community-token",
-        "solana cum",
-        "cum"
+        "community-token"
       ],
       "extensions": {
         "twitter": "https://twitter.com/SolanaCum",
@@ -22739,10 +22607,7 @@
       "logoURI": "https://cdn.jsdelivr.net/gh/MaloSkylar/GAWDtoken/GAWDlogo.jpg",
       "tags": [
         "Social-Coin"
-      ],
-      "extensions": {
-        "website": ""
-      }
+      ]
     },
     {
       "chainId": 101,
@@ -22898,10 +22763,7 @@
       "tags": [
         "utility-token",
         "lp-token",
-        "Arabic BitCoin",
-        "Arabic",
-        "Arab",
-        "Arabic Token",
+        "arabic-token",
         "utility-token",
         "lp-token"
       ],
@@ -23210,8 +23072,7 @@
         "UXP",
         "governance",
         "DAO",
-        "stablecoin",
-        "Web 3.0"
+        "stablecoin"
       ],
       "extensions": {
         "website": "https://uxd.fi/",
@@ -23230,10 +23091,7 @@
       "tags": [
         "utility-token",
         "wrapped"
-      ],
-      "extensions": {
-        "website": ""
-      }
+      ]
     },
     {
       "chainId": 101,
@@ -23245,8 +23103,7 @@
       "tags": [
         "nft",
         "game-coin",
-        "gaming",
-        "Blockchain Game"
+        "gaming"
       ],
       "extensions": {
         "website": "https://solvikings.com/",
@@ -23310,8 +23167,8 @@
       ],
       "extensions": {
         "website": "https://soltricks.io",
-        "discord ": "https://discord.soltricks.io",
-        "twitter ": "https://twitter.com/soltricks"
+        "discord": "https://discord.soltricks.io",
+        "twitter": "https://twitter.com/soltricks"
       }
     },
     {
@@ -23326,8 +23183,8 @@
       ],
       "extensions": {
         "website": "https://rendo.club",
-        "discord ": "https://discord.gg/SvNZZu6",
-        "twitter ": "https://twitter.com/rendo"
+        "discord": "https://discord.gg/SvNZZu6",
+        "twitter": "https://twitter.com/rendo"
       }
     },
     {
@@ -23342,7 +23199,7 @@
       ],
       "extensions": {
         "website": "https://www.samoinu.com",
-        "discord": "http://discord.gg/samoinu",
+        "discord": "https://discord.gg/samoinu",
         "twitter": "https://twitter.com/samo_inu"
       }
     },
@@ -23377,7 +23234,7 @@
       ],
       "extensions": {
         "website": "https://www.samoinu.com",
-        "discord": "http://discord.gg/samoinu",
+        "discord": "https://discord.gg/samoinu",
         "twitter": "https://twitter.com/samo_inu",
         "description": "Samo Inu is an hybrid meme coin with fun and social utilities"
       }
@@ -23472,7 +23329,7 @@
       ],
       "extensions": {
         "website": "https://zdrt.club",
-        "discord": "hhttps://discord.gg/VHpA4tQYXZ"
+        "discord": "https://discord.gg/VHpA4tQYXZ"
       }
     },
     {
@@ -23522,10 +23379,7 @@
       "name": "ACE",
       "decimals": 9,
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/5fhXkD8tXyDB9rmYZSNJ6LneLr2nMteMpCVxeDDEgXa3/logo.png",
-      "tags": [],
-      "extensions": {
-        "website": ""
-      }
+      "tags": []
     },
     {
       "chainId": 101,
@@ -23590,7 +23444,7 @@
       "extensions": {
         "twitter": "https://twitter.com/LordedgeSol",
         "website": "https://lordedgesol.com",
-        "Telegram": "https://t.me/lordedgesol"
+        "telegram": "https://t.me/lordedgesol"
       }
     },
     {
@@ -23713,7 +23567,7 @@
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/BQTN97PwrQGkbNepQxjvcYfRPYbPNgd5PqoioYwBt4qX/logo.png",
       "tags": [
         "DOA",
-        "Asgard Army",
+        "asgard-army",
         "nft"
       ],
       "extensions": {
@@ -23789,7 +23643,6 @@
       "extensions": {
         "website": "https://phantasia.app/",
         "twitter": "https://twitter.com/PhantasiaSports",
-        "email": "phantasia@phantasia.digital",
         "discord": "https://t.co/Vskz9PkBBC?amp=1"
       }
     },
@@ -23896,7 +23749,7 @@
         "twitter": "https://twitter.com/SOLGR_Official",
         "website": "https://sogrr.com",
         "discord": "https://discord.gg/2ZPNmRrNpW",
-        "Telegram": "https://t.me/SOLGR_Official"
+        "telegram": "https://t.me/SOLGR_Official"
       }
     },
     {
@@ -23916,7 +23769,7 @@
         "twitter": "https://twitter.com/SOLGR_Official",
         "website": "https://solgrr.com",
         "discord": "https://discord.gg/2ZPNmRrNpW",
-        "Telegram": "https://t.me/SOLGR_Official"
+        "telegram": "https://t.me/SOLGR_Official"
       }
     },
     {
@@ -23936,7 +23789,7 @@
         "twitter": "https://twitter.com/SOLGR_Official",
         "website": "https://solgrr.com",
         "discord": "https://discord.gg/2ZPNmRrNpW",
-        "Telegram": "https://t.me/SOLGR_Official"
+        "telegram": "https://t.me/SOLGR_Official"
       }
     },
     {
@@ -24007,7 +23860,7 @@
       "extensions": {
         "twitter": "https://twitter.com/ApemoonSOL",
         "website": "https://t.me/ApeMoonSOL",
-        "Telegram": "https://t.me/ApeMoonSOL"
+        "telegram": "https://t.me/ApeMoonSOL"
       }
     },
     {
@@ -24025,7 +23878,7 @@
       "extensions": {
         "twitter": "https://twitter.com/ApemoonSOL",
         "website": "https://t.me/ApeMoonSOL",
-        "Telegram": "https://t.me/ApeMoonSOL"
+        "telegram": "https://t.me/ApeMoonSOL"
       }
     },
     {
@@ -24192,11 +24045,11 @@
       "decimals": 0,
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/39cG39AZ4cG7oGNMe4RhD3xAzjy1nkiNgk8W6WbDCgeR/logo.png",
       "tags": [
-        "Payment Protocol",
+        "payment-protocol",
         "Payment",
         "Videos",
         "community",
-        "Live Stream"
+        "live-stream"
       ],
       "extensions": {
         "twitter": "https://twitter.com/xhamster_sol",
@@ -24351,7 +24204,7 @@
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/9tjgbaSSEyPgRgTLVaTzzZR46xPq1jU6d7fB217czRdK/logo.png",
       "tags": [
         "utility-token",
-        "meme token"
+        "meme-token"
       ]
     },
     {
@@ -24433,8 +24286,7 @@
       "extensions": {
         "website": "https://berscoin.com/",
         "youtube": "https://www.youtube.com/c/BersCoinBersTube",
-        "facebook": "https://www.facebook.com/berscoin",
-        "founder": "https://montblanc.ovh"
+        "facebook": "https://www.facebook.com/berscoin"
       }
     },
     {
@@ -24701,8 +24553,8 @@
       ],
       "extensions": {
         "website": "https://syncline.network",
-        "twitter ": "https://twitter.com/synclinenetwork",
-        "telegram ": "https://t.me/joinchat/SKSLdG0sF53TFK6_"
+        "twitter": "https://twitter.com/synclinenetwork",
+        "telegram": "https://t.me/joinchat/SKSLdG0sF53TFK6_"
       }
     },
     {
@@ -24784,7 +24636,7 @@
       "decimals": 9,
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/inL8PMVd6iiW3RCBJnr5AsrRN6nqr4BTrcNuQWQSkvY/logo-owl.png",
       "tags": [
-        "decentralized-reserve-currency",
+        "decentralizedreserve",
         "utility-token",
         "DeFi",
         "community-token"
@@ -24793,7 +24645,7 @@
         "coingeckoId": "invictus",
         "website": "https://invictusdao.fi/",
         "twitter": "https://twitter.com/InvictusDAO",
-        "discord": "http://discord.gg/invictusdao"
+        "discord": "https://discord.gg/invictusdao"
       }
     },
     {
@@ -24811,9 +24663,9 @@
         "DeFi"
       ],
       "extensions": {
-        "telegram": "https://www.t.me/leonidas_token",
+        "telegram": "https://t.me/leonidas_token",
         "website": "https://www.leonidastoken.com",
-        "twitter": "https://www.twitter.com/leonidas_token",
+        "twitter": "https://twitter.com/leonidas_token",
         "discord": "https://www.discord.com/invite/drN8FUruAu",
         "instagram": "https://www.instagram.com/leonidas_token",
         "reddit": "https://www.reddit.com/r/leonidas_token",
@@ -24879,9 +24731,9 @@
       "decimals": 6,
       "logoURI": "https://raw.githubusercontent.com/sol-farm/token-logos/dad49dff5a8cb4abc6c3ccae35dc845a2af46f98/tuBTC.png",
       "tags": [
-        "tulip protocol",
+        "tulip-protocol",
         "lending",
-        "collateral tokens"
+        "collateral-tokens"
       ],
       "extensions": {
         "website": "https://tulip.garden",
@@ -24897,9 +24749,9 @@
       "decimals": 6,
       "logoURI": "https://raw.githubusercontent.com/sol-farm/token-logos/dad49dff5a8cb4abc6c3ccae35dc845a2af46f98/tuORCA.png",
       "tags": [
-        "tulip protocol",
+        "tulip-protocol",
         "lending",
-        "collateral tokens"
+        "collateral-tokens"
       ],
       "extensions": {
         "website": "https://tulip.garden",
@@ -24915,9 +24767,9 @@
       "decimals": 9,
       "logoURI": "https://raw.githubusercontent.com/sol-farm/token-logos/dad49dff5a8cb4abc6c3ccae35dc845a2af46f98/tuSAMO.png",
       "tags": [
-        "tulip protocol",
+        "tulip-protocol",
         "lending",
-        "collateral tokens"
+        "collateral-tokens"
       ],
       "extensions": {
         "website": "https://tulip.garden",
@@ -24933,9 +24785,9 @@
       "decimals": 6,
       "logoURI": "https://raw.githubusercontent.com/sol-farm/token-logos/dad49dff5a8cb4abc6c3ccae35dc845a2af46f98/tuSRM.png",
       "tags": [
-        "tulip protocol",
+        "tulip-protocol",
         "lending",
-        "collateral tokens"
+        "collateral-tokens"
       ],
       "extensions": {
         "website": "https://tulip.garden",
@@ -24951,9 +24803,9 @@
       "decimals": 9,
       "logoURI": "https://raw.githubusercontent.com/sol-farm/token-logos/dad49dff5a8cb4abc6c3ccae35dc845a2af46f98/tumSOL.png",
       "tags": [
-        "tulip protocol",
+        "tulip-protocol",
         "lending",
-        "collateral tokens"
+        "collateral-tokens"
       ],
       "extensions": {
         "website": "https://tulip.garden",
@@ -24969,9 +24821,9 @@
       "decimals": 6,
       "logoURI": "https://raw.githubusercontent.com/sol-farm/token-logos/dad49dff5a8cb4abc6c3ccae35dc845a2af46f98/tuwhETH.png",
       "tags": [
-        "tulip protocol",
+        "tulip-protocol",
         "lending",
-        "collateral tokens"
+        "collateral-tokens"
       ],
       "extensions": {
         "website": "https://tulip.garden",

--- a/src/tokens/validate.sh
+++ b/src/tokens/validate.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+cue vet solana.tokenlist.json schema.cue -d '#Tokenlist'


### PR DESCRIPTION
This adds a Cue schema for the token list JSON file, derived
from the Uniswap JSON Schema.

Made some judgement calls on whether to clean up the data or
extend the schema to make it fit. In particular,
no symbols were changed since it's not clear whether anyone relies
on immutable symbol names, even though some of them are
*really* invalid. In a similar vein, we should consider pruning
the number of valid extensions - no explorer will possibly show
a dozen different types of external links.