### PR TITLE
automerge.go: telegram urls can apparently contain +s

### DIFF
--- a/automerge/schema.cue
+++ b/automerge/schema.cue
@@ -80,7 +80,7 @@ import (
 }
 
 #URL: =~ #"^(ipfs|http[s]?)://(?:[a-zA-Z]|[0-9]|[$-_@.&+#~]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+$"#
-#TelegramURL: =~ #"^https://t.me/((\w){5,32}|joinchat/[\w-]{16})$"#
+#TelegramURL: =~ #"^https://t.me/([\w\+]{5,32}|joinchat/[\w-]{16})$"#
 
 #Extensions: {
 	website?: #URL


### PR DESCRIPTION
e.g. https://github.com/solana-labs/token-list/pull/5915/files fails because of the `+` in the url