### PR TITLE
fix BAD json

### DIFF
--- a/src/tokens/solana.tokenlist.json
+++ b/src/tokens/solana.tokenlist.json
@@ -57,7 +57,7 @@
   },
   "timestamp": "2021-03-03T19:57:21+0000",
   "tokens": [
-{
+    {
       "chainId": 101,
       "address": "G6nZYEvhwFxxnp1KZr1v9igXtipuB5zL6oDGNMRZqF3q",
       "symbol": "BAD",
@@ -66,11 +66,11 @@
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/G6nZYEvhwFxxnp1KZr1v9igXtipuB5zL6oDGNMRZqF3q/EABadlogo.PNG",
       "tags": [
         "utility-token",
-	"community-token",
-	"meme-token"
+        "community-token",
+        "meme-token"
       ],
       "extensions": {
-        "twitter": "https://twitter.com/EABadtoken",
+        "twitter": "https://twitter.com/EABadtoken"
       }
     },
     {


### PR DESCRIPTION
The recent PR #5918 to add the BAD token introduced malformed JSON that
breaks parsers of the file. JSON does not allow trailing commas in
objects (see https://json.org). This patch fixes the JSON format to be
readable once more.
