### PR TITLE
Renamed scam token to prevent people from visitting phishing website.

### DIFF
--- a/src/tokens/solana.tokenlist.json
+++ b/src/tokens/solana.tokenlist.json
@@ -52434,8 +52434,8 @@
     {
       "chainId": 101,
       "address": "13cbpw6uN6wXVaQk6ngedAErceLLhyo1mgzoDpoUgCJE",
-      "symbol": "SOLNFTEvent.com",
-      "name": "SOLNFTEvent.com",
+      "symbol": "",
+      "name": "PHISHING SCAM TOKEN, PLEASE IGNORE",
       "decimals": 0,
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/13cbpw6uN6wXVaQk6ngedAErceLLhyo1mgzoDpoUgCJE/logo.png"
     },


### PR DESCRIPTION
Phisher re-committed their scam token. We need to rename to prevent auto re-add.