### PR TITLE
addendum to #9308, token blanked out needs to have nonempty symbol

### DIFF
--- a/src/tokens/solana.tokenlist.json
+++ b/src/tokens/solana.tokenlist.json
@@ -52437,7 +52437,7 @@
     {
       "chainId": 101,
       "address": "13cbpw6uN6wXVaQk6ngedAErceLLhyo1mgzoDpoUgCJE",
-      "symbol": "",
+      "symbol": "PHISHINGSCAM",
       "name": "PHISHING SCAM TOKEN, PLEASE IGNORE",
       "decimals": 0,
       "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/13cbpw6uN6wXVaQk6ngedAErceLLhyo1mgzoDpoUgCJE/logo.png"


### PR DESCRIPTION
addendum to #9308, token blanked out needs to have nonempty symbol to avoid causing failures for other commits