### PR TITLE
Publish package with `npm` instead of `yarn`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,6 +33,6 @@ jobs:
       - run: yarn run version --patch
       - run: git push --follow-tags origin main
       - run: yarn run purge:cdn
-      - run: yarn publish
+      - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}


### PR DESCRIPTION
Fixes https://github.com/solana-labs/token-list/issues/8358

Turns out `assets` indeed are not supposed to be included in the package.

However, since so far `token-list` was being published with `yarn`, it was suffering from a `yarn` bug, which makes it not handle ignored and unignored files properly if there is a negative expression in `package.json#files` (there are numerous issues with confused people in Yarn repo, one of them — https://github.com/yarnpkg/yarn/issues/8332).

This pull request proposes changes publishing command from `yarn publish` to `npm publish` which in itself isn't a huge change (the effect should be the same), but since we'll be using NPM to pack the tarball files will be properly included/excluded and the resulting package will be 5.6 MB unpacked instead of >200 MB.

Alternative solutions:
- remove negative `!**/*.spec.*` from `package.json#files`, leave `yarn publish`, ship library with tests
- remove negative `!**/*.spec.*` from `package.json#files`, leave `yarn publish`, figure out some other way of ignoring files that Yarn will handle correctly (some mix of `.npmignore`, `#files`?)
- publish in a two step process — first pack with NPM, then publish with Yarn (what difference would it make?)