### PR TITLE
Enable Static strategy to be pruned by tree-shaking

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@solana/spl-token-registry",
   "version": "0.2.1221",
   "description": "Solana Token Registry",
+  "sideEffects": false,
   "main": "dist/main/index.js",
   "typings": "dist/main/index.d.ts",
   "module": "dist/module/index.js",

--- a/src/lib/tokenlist.spec.ts
+++ b/src/lib/tokenlist.spec.ts
@@ -5,13 +5,13 @@ import test from 'ava';
 import {
   CLUSTER_SLUGS,
   ENV,
-  Strategy,
+  StaticStrategy,
   TokenInfo,
   TokenListProvider,
 } from './tokenlist';
 
 test('Token list is filterable by a tag', async (t) => {
-  const list = (await new TokenListProvider().resolve(Strategy.Static))
+  const list = (await new TokenListProvider().resolve(new StaticStrategy()))
     .filterByChainId(ENV.MainnetBeta)
     .filterByTag('nft')
     .getList();
@@ -20,7 +20,7 @@ test('Token list is filterable by a tag', async (t) => {
 });
 
 test('Token list can exclude by a tag', async (t) => {
-  const list = (await new TokenListProvider().resolve(Strategy.Static))
+  const list = (await new TokenListProvider().resolve(new StaticStrategy()))
     .filterByChainId(ENV.MainnetBeta)
     .excludeByTag('nft')
     .getList();
@@ -29,7 +29,7 @@ test('Token list can exclude by a tag', async (t) => {
 });
 
 test('Token list can exclude by a chain', async (t) => {
-  const list = (await new TokenListProvider().resolve(Strategy.Static))
+  const list = (await new TokenListProvider().resolve(new StaticStrategy()))
     .excludeByChainId(ENV.MainnetBeta)
     .getList();
 
@@ -37,14 +37,14 @@ test('Token list can exclude by a chain', async (t) => {
 });
 
 test('Token list returns new object upon filter', async (t) => {
-  const list = await new TokenListProvider().resolve(Strategy.Static);
+  const list = await new TokenListProvider().resolve(new StaticStrategy());
   const filtered = list.filterByChainId(ENV.MainnetBeta);
   t.true(list !== filtered);
   t.true(list.getList().length !== filtered.getList().length);
 });
 
 test('Token list throws error when calling filterByClusterSlug with slug that does not exist', async (t) => {
-  const list = await new TokenListProvider().resolve(Strategy.Static);
+  const list = await new TokenListProvider().resolve(new StaticStrategy());
   const error = await t.throwsAsync(
     async () => list.filterByClusterSlug('whoop'),
     { instanceOf: Error }
@@ -65,7 +65,7 @@ test('Token list is a valid json', async (t) => {
 });
 
 test('Token list does not have duplicate entries', async (t) => {
-  const list = await new TokenListProvider().resolve(Strategy.Static);
+  const list = await new TokenListProvider().resolve(new StaticStrategy());
   list
     .filterByChainId(ENV.MainnetBeta)
     .getList()


### PR DESCRIPTION
👋 Hi there,

## Problem
As mentioned in #11897, the bundle size of this package is very large due to the static `solana.tokenlist.json` file being automatically added to every import.

In my own applications, I've been using a fork of this package that simply does not contain the `Static` strategy and does not import the JSON file. Instead, it only relies on `fetch` calls to retrieve the token list.

However, I couldn't reproduce this solution in the main repo because A) people might want to rely on this `Static` strategy and B) the tests do rely on it.

## Solution
Therefore, I ended up searching for ways to make this package more "Tree-Shaking" friendly and I came up with a solution that will allow bundlers such as Webpack or Rollup to automatically prune that big JSON file if and only if it isn't used by the application.

## Changes
- I added the `"sideEffects": false` property on the `package.json` to tell bundlers that this package does not have any side effects. This means bundlers won't have to look at all of the files just in case they provide a global variable or a polyfill because they do not. Instead, they will be able to skip unused files such as the `solana.tokenlist.json` file.
- I had to remove the `Strategy` enum and the `TokenProvider.strategies` object because they forced bundlers to think that all strategies (and thus the `Static` strategy) were used even when they were not. Instead, I had to make the `TokenProvider.resolve` method accept a strategy object constructed by the application so bundlers would understand which strategy is being used and prune the others.
- I took the liberty to give the strategy classes shorter names since they will now be explicitly imported by applications.

## Usage

The default usage relying on the `CDN` strategy is unchanged.

```js
import { TokenListProvider } from '@solana/spl-token-registry';

const container = await (new TokenListProvider).resolve();
const list = container.getList();
```

However, in order to use a different strategy, we now need to import the class and instantiate it ourselves like so.

```js
import { TokenListProvider, StaticStrategy } from '@solana/spl-token-registry';

const container = await (new TokenListProvider).resolve(new StaticStrategy());
const list = container.getList();
```

⚠️ **This is a breaking change!** As explained in the previous section, this change was necessary to allow bundlers to prune unused strategies.

## Tests

I tested this package using `yarn link` into another application using Webpack with the following configurations to test tree-shaking.

```js
const path = require("path");

module.exports = {
  entry: "./src/index.js",
  output: {
    filename: "main.js",
    path: path.resolve(__dirname, "dist"),
  },
  mode: "development",
  optimization: {
    usedExports: true,
    innerGraph: true,
    sideEffects: true,
  },
  devtool: false,
};
```

Here are the results I got when building the assets.

### A) Using the default strategy (CDN)

```js
import { TokenListProvider } from '@solana/spl-token-registry';

const container = await (new TokenListProvider).resolve();
const list = container.getList();
```

Bundle size: **26 KiB**
Output:

```shell
asset main.js 26 KiB [emitted] (name: main)
runtime modules 663 bytes 3 modules
orphan modules 1.68 MiB [orphan] 2 modules
cacheable modules 22.1 KiB
  ./src/index.js 226 bytes [built] [code generated]
  ../token-list/dist/module/lib/tokenlist.js 7.07 KiB [built] [code generated]
  ../token-list/node_modules/cross-fetch/dist/browser-ponyfill.js 14.8 KiB [built] [code generated]
webpack 5.65.0 compiled successfully in 135 ms
```

### B) Using the Static strategy

```js
import { TokenListProvider, StaticStrategy } from '@solana/spl-token-registry';

const container = await (new TokenListProvider).resolve(new StaticStrategy());
const list = container.getList();
```

Bundle size: **1.7 MiB**
Output:

```shell
asset main.js 1.7 MiB [emitted] (name: main)
runtime modules 663 bytes 3 modules
orphan modules 251 bytes [orphan] 1 module
cacheable modules 1.7 MiB
  modules by path ../token-list/dist/module/ 1.68 MiB
    ../token-list/dist/module/lib/tokenlist.js 7.07 KiB [built] [code generated]
    ../token-list/dist/module/tokens/solana.tokenlist.json 1.68 MiB [built] [code generated]
  ./src/index.js 246 bytes [built] [code generated]
  ../token-list/node_modules/cross-fetch/dist/browser-ponyfill.js 14.8 KiB [built] [code generated]
webpack 5.65.0 compiled successfully in 168 ms
```

### C) Using another non-static strategy

```js
import { TokenListProvider, GitHubStrategy } from '@solana/spl-token-registry';

const container = await (new TokenListProvider).resolve(new GitHubStrategy());
const list = container.getList();
```

Bundle size: **26.1 KiB**
Output:

```shell
asset main.js 26.1 KiB [emitted] (name: main)
runtime modules 663 bytes 3 modules
orphan modules 1.68 MiB [orphan] 2 modules
cacheable modules 22.1 KiB
  ./src/index.js 246 bytes [built] [code generated]
  ../token-list/dist/module/lib/tokenlist.js 7.07 KiB [built] [code generated]
  ../token-list/node_modules/cross-fetch/dist/browser-ponyfill.js 14.8 KiB [built] [code generated]
webpack 5.65.0 compiled successfully in 134 ms
```

## Final words

Thanks for reading this far, let me know if you have any questions.

This PR closes #11897