### PR TITLE
update OHM to OHM_v1 due to olympus migration

### DIFF
--- a/src/tokens/solana.tokenlist.json
+++ b/src/tokens/solana.tokenlist.json
@@ -24633,8 +24633,8 @@
     {
       "chainId": 101,
       "address": "Afe9gSG8NcWicJtC58tUPGWG6pUcdK29d59BJuSAsePJ",
-      "symbol": "OHM",
-      "name": "Olympus (Wormhole)",
+      "symbol": "OHM_v1",
+      "name": "Olympus V1 (Wormhole)",
       "decimals": 8,
       "logoURI": "https://cloudflare-ipfs.com/ipfs/QmcDGyz7Ag6PJB7zHQt1uMnJkFjvawAGwWp2UbmoEAtpXp/",
       "tags": [
@@ -24644,8 +24644,7 @@
       "extensions": {
         "address": "0x64aa3364f17a4d01c6f1751fd97c2bd3d7e7f1d5",
         "assetContract": "https://etherscan.io/address/0x64aa3364f17a4d01c6f1751fd97c2bd3d7e7f1d5",
-        "bridgeContract": "https://etherscan.io/address/0x3ee18B2214AFF97000D974cf647E7C347E8fa585",
-        "coingeckoId": "olympus"
+        "bridgeContract": "https://etherscan.io/address/0x3ee18B2214AFF97000D974cf647E7C347E8fa585"
       }
     },
     {


### PR DESCRIPTION
update OHM to OHM_v1 due to olympus migration, see https://docs.olympusdao.finance/main/basics/migration
