### PR TITLE
fix: protect against the `tokens` property` being `undefined`

### DIFF
--- a/src/lib/tokenlist.ts
+++ b/src/lib/tokenlist.ts
@@ -104,7 +104,7 @@ const queryJsonFiles = async (files: string[]) => {
   )) as TokenList[];
 
   return responses
-    .map((tokenlist: TokenList) => tokenlist.tokens)
+    .map((tokenlist: TokenList) => tokenlist.tokens || [])
     .reduce((acc, arr) => (acc as TokenInfo[]).concat(arr), []);
 };
 
@@ -117,7 +117,7 @@ export enum Strategy {
 
 export class StaticTokenListResolutionStrategy {
   resolve = () => {
-    return tokenlist.tokens;
+    return tokenlist.tokens || [];
   };
 }
 


### PR DESCRIPTION
#### Problem

Sometimes the endpoint (eg. https://token-list.solana.com/solana.tokenlist.json) returns an empty response (eg. a literal `{}`). In cases like that, `tokenlist.tokens` will be `undefined`.

#### Summary of changes

* When `tokens` is `undefined`, default to an empty array so that the rest of the program doesn't fatal.