### PR TITLE
docs: fix render icon for token in react example

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ new TokenListProvider().resolve().then((tokens) => {
 
 ```typescript jsx
 import React, { useEffect, useState } from 'react';
-import { TokenListProvider, TokenInfo } from '@solana/spl-token-registry';
+import { TokenListProvider, TokenInfo, ENV } from '@solana/spl-token-registry';
 
 
 export const Icon = (props: { mint: string }) => {
@@ -70,8 +70,8 @@ export const Icon = (props: { mint: string }) => {
   const token = tokenMap.get(props.mint);
   if (!token || !token.logoURI) return null;
 
-  return (<img src={token.logoURI} />);
-
+  return (<img src={token.logoURI} alt={token.name + " logo"} />);
+}
 ```
 
 # Adding new token


### PR DESCRIPTION
The current [Render icon for token in React](https://github.com/solana-labs/token-list/tree/c1ff0ac267d03397f56a7030b02d357f90d49f79#render-icon-for-token-in-react) example is broken when simply copy/pasted. 

This PR fixes the following issues:
- Adds a missing import for `ENV`
- Adds a missing closing bracket
- Includes a required `alt` tag for the return `img`