### PR TITLE
add stablecoin tag to agEUR (Wormhole)

### DIFF
--- a/src/tokens/solana.tokenlist.json
+++ b/src/tokens/solana.tokenlist.json
@@ -67,7 +67,8 @@
       "tags": [
         "ethereum",
         "wrapped",
-        "wormhole"
+        "wormhole",
+        "stablecoin"
       ],
       "extensions": {
         "address": "0x1a7e4e63778B4f12a199C062f3eFdD288afCBce8",


### PR DESCRIPTION
agEUR (Wormhole) is a EURO stablecoin.
We added the stablecoin tag to the token definition.
