### PR TITLE
Added ids for networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ export const Icon = (props: { mint: string }) => {
 To add a new token, add another json block to the large `tokens` list in `src/tokens/solana.tokenlist.json` and submit a PR.
 
 Tips:
+* `chainId`
+  * MainnetBeta = 101
+  * Testnet = 102
+  * Devnet = 103
 * `logoURI` 
   * should point to a `png`, `jpg`, or `svg`.
   * the logo can be hosted in this repo in `assets/mainnet/TOKEN_ADDRESS/FILE` 


### PR DESCRIPTION
Chain Ids for networks were not declared neither in this repo or solona docs. Ids were added to readme file in this repo.

Source: https://github.com/solana-labs/token-list/blob/e5d4a6aee1bf0b1c0b13d17cf754503c9b1c0a6c/src/lib/tokenlist.ts#L5-L9